### PR TITLE
talk-llama : fix n_gpu_layers usage again

### DIFF
--- a/examples/talk-llama/talk-llama.cpp
+++ b/examples/talk-llama/talk-llama.cpp
@@ -267,7 +267,7 @@ int main(int argc, char ** argv) {
 
     auto lmparams = llama_model_default_params();
     if (!params.use_gpu) {
-        lcparams.lmparams = 0;
+        lmparams.n_gpu_layers = 0;
     }
 
     struct llama_model * model_llama = llama_load_model_from_file(params.model_llama.c_str(), lmparams);


### PR DESCRIPTION
Context: [#https://github.com/ggerganov/whisper.cpp/pull/1441#issuecomment-1797160197](https://github.com/ggerganov/whisper.cpp/pull/1441#issuecomment-1797160197)

@bobqianic I confirmed it works:

```bash
➜  whisper.cpp git:(fix-talk-llama-build-2) make talk-llama
I whisper.cpp build info: 
I UNAME_S:  Darwin
I UNAME_P:  arm
I UNAME_M:  arm64
I CFLAGS:   -I.              -O3 -DNDEBUG -std=c11   -fPIC -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -pthread -DGGML_USE_ACCELERATE -DGGML_USE_METAL
I CXXFLAGS: -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -pthread -DGGML_USE_METAL
I LDFLAGS:   -framework Accelerate -framework Foundation -framework Metal -framework MetalKit
I CC:       Apple clang version 15.0.0 (clang-1500.0.40.1)
I CXX:      Apple clang version 15.0.0 (clang-1500.0.40.1)

c++ -I. -I./examples -O3 -DNDEBUG -std=c++11 -fPIC -D_XOPEN_SOURCE=600 -D_DARWIN_C_SOURCE -pthread -DGGML_USE_METAL examples/talk-llama/talk-llama.cpp examples/talk-llama/llama.cpp examples/common.cpp examples/common-ggml.cpp examples/common-sdl.cpp ggml.o ggml-alloc.o ggml-backend.o ggml-quants.o whisper.o ggml-metal.o -o talk-llama `sdl2-config --cflags --libs`  -framework Accelerate -framework Foundation -framework Metal -framework MetalKit
examples/talk-llama/talk-llama.cpp:401:9: warning: 'llama_eval' is deprecated: use llama_decode() instead [-Wdeprecated-declarations]
    if (llama_eval(ctx_llama, embd_inp.data(), embd_inp.size(), 0)) {
        ^
examples/talk-llama/llama.h:436:15: note: 'llama_eval' has been explicitly marked deprecated here
    LLAMA_API DEPRECATED(int llama_eval(
              ^
examples/talk-llama/llama.h:31:56: note: expanded from macro 'DEPRECATED'
#    define DEPRECATED(func, hint) func __attribute__((deprecated(hint)))
                                                       ^
examples/talk-llama/talk-llama.cpp:584:29: warning: 'llama_eval' is deprecated: use llama_decode() instead [-Wdeprecated-declarations]
                        if (llama_eval(ctx_llama, embd.data(), embd.size(), n_past)) {
                            ^
examples/talk-llama/llama.h:436:15: note: 'llama_eval' has been explicitly marked deprecated here
    LLAMA_API DEPRECATED(int llama_eval(
              ^
examples/talk-llama/llama.h:31:56: note: expanded from macro 'DEPRECATED'
#    define DEPRECATED(func, hint) func __attribute__((deprecated(hint)))
                                                       ^
2 warnings generated.
```