### PR TITLE
Incorrect timestamps

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6241,14 +6241,13 @@ int whisper_full_with_state(
                         }
                         text = "";
                         t0 = t1;
-                        while (i < (int) tokens_cur.size() && tokens_cur[i].id > whisper_token_beg(ctx)) {
+                        while (i + 1 < (int) tokens_cur.size() && tokens_cur[i + 1].id > whisper_token_beg(ctx)) {
+                            i++;
                             if (params.print_special) {
                                 text += whisper_token_to_str(ctx, tokens_cur[i].id);
                             }
                             t0 = seek + 2 * (tokens_cur[i].tid - whisper_token_beg(ctx));
-                            i++;
                         }
-                        i--;
                         i0 = i + 1;
                         speaker_turn_next = false;
                     }

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6240,11 +6240,15 @@ int whisper_full_with_state(
                             }
                         }
                         text = "";
+                        t0 = t1;
                         while (i < (int) tokens_cur.size() && tokens_cur[i].id > whisper_token_beg(ctx)) {
+                            if (params.print_special) {
+                                text += whisper_token_to_str(ctx, tokens_cur[i].id);
+                            }
+                            t0 = seek + 2 * (tokens_cur[i].tid - whisper_token_beg(ctx));
                             i++;
                         }
                         i--;
-                        t0 = t1;
                         i0 = i + 1;
                         speaker_turn_next = false;
                     }
@@ -6261,8 +6265,8 @@ int whisper_full_with_state(
                             printf("[%s --> %s]  %s\n", to_timestamp(tt0).c_str(), to_timestamp(tt1).c_str(), text.c_str());
                         } else {
                             printf("%s", text.c_str());
-                            fflush(stdout);
                         }
+                        fflush(stdout);
                     }
 
                     result_all.push_back({ tt0, tt1, text, {} , speaker_turn_next });


### PR DESCRIPTION
Fixes #2271

- Adds consecutive timestamps after end of last segment as the new starting ts
- Add these timestamp to output when "print-special" enabled
- Fixes fflush usage in live reporting

I was not able to test this with the special "token_timestamps" option.

NB: This is my first Github PR so go easy on me.