### PR TITLE
Wrong implementation of carry_initial_prompt

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -482,13 +482,14 @@ extern "C" {
         int duration_ms;        // audio duration to process in ms
 
         bool translate;
-        bool no_context;        // do not use past transcription (if any) as initial prompt for the decoder
-        bool no_timestamps;     // do not generate timestamps
-        bool single_segment;    // force single segment output (useful for streaming)
-        bool print_special;     // print special tokens (e.g. <SOT>, <EOT>, <BEG>, etc.)
-        bool print_progress;    // print progress information
-        bool print_realtime;    // print results from within whisper.cpp (avoid it, use callback instead)
-        bool print_timestamps;  // print timestamps for each text segment when printing realtime
+        bool no_context;           // do not use past transcription (if any) as initial prompt for the decoder
+        bool carry_initial_prompt; // carry the initial prompt to the next call
+        bool no_timestamps;        // do not generate timestamps
+        bool single_segment;       // force single segment output (useful for streaming)
+        bool print_special;        // print special tokens (e.g. <SOT>, <EOT>, <BEG>, etc.)
+        bool print_progress;       // print progress information
+        bool print_realtime;       // print results from within whisper.cpp (avoid it, use callback instead)
+        bool print_timestamps;     // print timestamps for each text segment when printing realtime
 
         // [EXPERIMENTAL] token-level timestamps
         bool  token_timestamps; // enable token-level timestamps


### PR DESCRIPTION
When transcribing long form content, it is extremely helpful to give whisper information on how to spell names/terms (people, places, companies, products, jargon, etc.). This can be done for the beginning of the audio file using the 'initial prompt', but since this prompt is not persisted, this information is quickly lost.

OpenAI recently added a carry_initial_prompt option and huggingface's transformers have a prompt_condition_type=‘all-segments’ option - both of which try to ensure that the 'initial prompt' is always in the context.

The way I believe they do this is by saying that in each 30s segment's prompt, they prepend the initial prompt into the first 224 tokens of context, which are usually just the most recent 224 tokens of previous transcriptions (and as always, leaving at least 224 tokens for the actual transcription).

OpenAI's python implementation is very simple: https://github.com/openai/whisper/pull/2343/files

My hope is that it's also simple to implement this feature in this code base, like OpenAI and Huggingface transformers have done.

However, I
1. don't understand C/C++
2. don't understand the technical details of Whisper, Transformers, GPU code, etc.
3. the whisper.cpp file is too large even for Claude 3.5 Sonnet's and OpenAI's context windows, so they can't help

So here's a PR, mostly generated by LLMs seeing subsections of the codebase. The code itself doesn't work at all, and is probably completely invalid and bad.

But I hope this PR serves as a suggestion of how to port this simple OpenAI implementation of carry_initial_prompt over, and maybe even serves as motivation to finish this PR / build your own commit.

Alternatively, if you could point me in the right direction / write some pseudo code of what would have to happen, I'll be happy to attempt writing it!

And in any case, happy New Year!