### PR TITLE
Add an audio function to retrieve the audio data since last time.

### DIFF
--- a/examples/common-sdl.h
+++ b/examples/common-sdl.h
@@ -30,6 +30,8 @@ public:
 
     // get audio data from the circular buffer
     void get(int ms, std::vector<float> & audio);
+    void next(std::vector<float> & audio);
+    void get_n(size_t n_samples, std::vector<float> & audio);
 
 private:
     SDL_AudioDeviceID m_dev_id_in = 0;
@@ -43,6 +45,7 @@ private:
     std::vector<float> m_audio;
     size_t             m_audio_pos = 0;
     size_t             m_audio_len = 0;
+    size_t             m_audio_nxt = 0;
 };
 
 // Return false if need to quit

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -241,7 +241,7 @@ int main(int argc, char ** argv) {
 
         if (!use_vad) {
             while (true) {
-                audio.get(params.step_ms, pcmf32_new);
+                audio.next(pcmf32_new);
 
                 if ((int) pcmf32_new.size() > 2*n_samples_step) {
                     fprintf(stderr, "\n\n%s: WARNING: cannot process audio fast enough, dropping audio ...\n\n", __func__);
@@ -250,7 +250,6 @@ int main(int argc, char ** argv) {
                 }
 
                 if ((int) pcmf32_new.size() >= n_samples_step) {
-                    audio.clear();
                     break;
                 }
 


### PR DESCRIPTION
Without it, `stream --save-audio` produces somehow choppy wav: `stream` calculates t_diff in milliseconds
and combine audio pieces which are about step_ms long.

WHISPER_SAMPLE_RATE / 1000 == only 16

but surprisingly human ears seem to be able to hear the gap as a noise.