### PR TITLE
Update jni.c for enabling word timestamp in Android

### DIFF
--- a/examples/whisper.android/app/src/main/java/com/whispercppdemo/ui/main/MainScreenViewModel.kt
+++ b/examples/whisper.android/app/src/main/java/com/whispercppdemo/ui/main/MainScreenViewModel.kt
@@ -143,7 +143,7 @@ class MainScreenViewModel(private val application: Application) : ViewModel() {
             printMessage("${data.size / (16000 / 1000)} ms\n")
             printMessage("Transcribing data...\n")
             val start = System.currentTimeMillis()
-            val text = whisperContext?.transcribeData(data)
+            val text = whisperContext?.transcribeDataWithParams(data, tokenTimestamps = false, splitOnWord = false, maxLen = 1)
             val elapsed = System.currentTimeMillis() - start
             printMessage("Done ($elapsed ms): \n$text\n")
         } catch (e: Exception) {

--- a/examples/whisper.android/app/src/main/java/com/whispercppdemo/ui/main/MainScreenViewModel.kt
+++ b/examples/whisper.android/app/src/main/java/com/whispercppdemo/ui/main/MainScreenViewModel.kt
@@ -143,7 +143,7 @@ class MainScreenViewModel(private val application: Application) : ViewModel() {
             printMessage("${data.size / (16000 / 1000)} ms\n")
             printMessage("Transcribing data...\n")
             val start = System.currentTimeMillis()
-            val text = whisperContext?.transcribeDataWithParams(data, tokenTimestamps = false, splitOnWord = false, maxLen = 1)
+            val text = whisperContext?.transcribeData(data, tokenTimestamps = false, splitOnWord = false, maxLen = 1)
             val elapsed = System.currentTimeMillis() - start
             printMessage("Done ($elapsed ms): \n$text\n")
         } catch (e: Exception) {

--- a/examples/whisper.android/lib/src/main/java/com/whispercpp/whisper/LibWhisper.kt
+++ b/examples/whisper.android/lib/src/main/java/com/whispercpp/whisper/LibWhisper.kt
@@ -16,11 +16,11 @@ class WhisperContext private constructor(private var ptr: Long) {
         Executors.newSingleThreadExecutor().asCoroutineDispatcher()
     )
 
-    suspend fun transcribeData(data: FloatArray, printTimestamp: Boolean = true): String = withContext(scope.coroutineContext) {
+    suspend fun transcribeData(data: FloatArray, printTimestamp: Boolean = true, tokenTimestamps: Boolean = false, splitOnWord: Boolean = false, maxLen: Int): String = withContext(scope.coroutineContext) {
         require(ptr != 0L)
         val numThreads = WhisperCpuConfig.preferredThreadCount
         Log.d(LOG_TAG, "Selecting $numThreads threads")
-        WhisperLib.fullTranscribe(ptr, numThreads, data)
+        WhisperLib.fullTranscribe(ptr, numThreads, data, tokenTimestamps, splitOnWord, maxLen)
         val textCount = WhisperLib.getTextSegmentCount(ptr)
         return@withContext buildString {
             for (i in 0 until textCount) {
@@ -134,7 +134,7 @@ private class WhisperLib {
         external fun initContextFromAsset(assetManager: AssetManager, assetPath: String): Long
         external fun initContext(modelPath: String): Long
         external fun freeContext(contextPtr: Long)
-        external fun fullTranscribe(contextPtr: Long, numThreads: Int, audioData: FloatArray)
+        external fun fullTranscribe(contextPtr: Long, numThreads: Int, audioData: FloatArray, tokenTimestamps: Boolean, splitOnWord: Boolean, maxLen: Int)
         external fun getTextSegmentCount(contextPtr: Long): Int
         external fun getTextSegment(contextPtr: Long, index: Int): String
         external fun getTextSegmentT0(contextPtr: Long, index: Int): Long

--- a/examples/whisper.android/lib/src/main/jni/whisper/jni.c
+++ b/examples/whisper.android/lib/src/main/jni/whisper/jni.c
@@ -181,6 +181,9 @@ Java_com_whispercpp_whisper_WhisperLib_00024Companion_fullTranscribe(
     params.offset_ms = 0;
     params.no_context = true;
     params.single_segment = false;
+    params.token_timestamps = true; // Enable for word level timestamps
+    params.split_on_word = true; // Enable for word level timestamps
+    params.max_len = 1; // Set number of words in a line
 
     whisper_reset_timings(context);
 

--- a/examples/whisper.android/lib/src/main/jni/whisper/jni.c
+++ b/examples/whisper.android/lib/src/main/jni/whisper/jni.c
@@ -163,7 +163,7 @@ Java_com_whispercpp_whisper_WhisperLib_00024Companion_freeContext(
 
 JNIEXPORT void JNICALL
 Java_com_whispercpp_whisper_WhisperLib_00024Companion_fullTranscribe(
-        JNIEnv *env, jobject thiz, jlong context_ptr, jint num_threads, jfloatArray audio_data) {
+        JNIEnv *env, jobject thiz, jlong context_ptr, jint num_threads, jfloatArray audio_data, jboolean token_timestamps, jboolean split_on_word, jint max_len) {
     UNUSED(thiz);
     struct whisper_context *context = (struct whisper_context *) context_ptr;
     jfloat *audio_data_arr = (*env)->GetFloatArrayElements(env, audio_data, NULL);
@@ -181,9 +181,9 @@ Java_com_whispercpp_whisper_WhisperLib_00024Companion_fullTranscribe(
     params.offset_ms = 0;
     params.no_context = true;
     params.single_segment = false;
-    params.token_timestamps = false; // Set true for word level timestamps
-    params.split_on_word = false; // Set true for word level timestamps
-    params.max_len = 1; // Set number of words in a line
+    params.token_timestamps = token_timestamps;
+    params.split_on_word = split_on_word;
+    params.max_len = max_len;
 
     whisper_reset_timings(context);
 

--- a/examples/whisper.android/lib/src/main/jni/whisper/jni.c
+++ b/examples/whisper.android/lib/src/main/jni/whisper/jni.c
@@ -181,8 +181,8 @@ Java_com_whispercpp_whisper_WhisperLib_00024Companion_fullTranscribe(
     params.offset_ms = 0;
     params.no_context = true;
     params.single_segment = false;
-    params.token_timestamps = true; // Enable for word level timestamps
-    params.split_on_word = true; // Enable for word level timestamps
+    params.token_timestamps = false; // Set true for word level timestamps
+    params.split_on_word = false; // Set true for word level timestamps
     params.max_len = 1; // Set number of words in a line
 
     whisper_reset_timings(context);


### PR DESCRIPTION
Update jni.c for enabling word level timestamps in whisper.cpp Android 

Set to optional.

Default is set to off.

If anyone wants can turn it to true for enabling word Level Timestamps 