### PR TITLE
xcframework : add support for CoreML to ios/macOS

### DIFF
--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -246,7 +246,7 @@ combine_static_libraries() {
         "${base_dir}/${build_dir}/ggml/src/ggml-blas/${release_dir}/libggml-blas.a"
     )
     if [[ "$platform" == "macos" || "$platform" == "ios" ]]; then
-        echo "Adding libwhisper.coreml library the build."
+        echo "Adding libwhisper.coreml library to the build."
         libs+=(
             "${base_dir}/${build_dir}/src/${release_dir}/libwhisper.coreml.a"
         )


### PR DESCRIPTION
This commit add support for compiling whisper with CoreML support for iOS and macOS.

The motivation for this change is it will allow users to use a Core ML model or fall back to a ggml model if Core ML is not available.

With the updated xcframework, I was able to run the whisper.objc example and successfully load a Core ML model:
```console
whisper_init_state: loading Core ML model from '/Users/danbev/Library/Developer/CoreSimulator/Devices/25E8C27D-0253-4281-AF17-C3F2A4D1D8F4/data/Containers/Bundle/Application/B81F6FF0-BF1A-40DF-AC2A-3908EC4BCC9A/whisper.objc.app/ggml-base.en-encoder.mlmodelc'
whisper_init_state: first run on a device may take a while ...
whisper_init_state: Core ML model loaded
```