### PR TITLE
whisper : fix "bench-all outputs an invalid result on larger models"

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4276,11 +4276,11 @@ void whisper_print_timings(struct whisper_context * ctx) {
 
         WHISPER_LOG_INFO("%s:     fallbacks = %3d p / %3d h\n", __func__, ctx->state->n_fail_p, ctx->state->n_fail_h);
         WHISPER_LOG_INFO("%s:      mel time = %8.2f ms\n", __func__, ctx->state->t_mel_us / 1000.0f);
-        WHISPER_LOG_INFO("%s:   sample time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_sample_us, n_sample, 1e-3f * ctx->state->t_sample_us / n_sample);
-        WHISPER_LOG_INFO("%s:   encode time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_encode_us, n_encode, 1e-3f * ctx->state->t_encode_us / n_encode);
-        WHISPER_LOG_INFO("%s:   decode time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_decode_us, n_decode, 1e-3f * ctx->state->t_decode_us / n_decode);
-        WHISPER_LOG_INFO("%s:   batchd time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_batchd_us, n_batchd, 1e-3f * ctx->state->t_batchd_us / n_batchd);
-        WHISPER_LOG_INFO("%s:   prompt time = %8.2f ms / %5d runs (%8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_prompt_us, n_prompt, 1e-3f * ctx->state->t_prompt_us / n_prompt);
+        WHISPER_LOG_INFO("%s:   sample time = %8.2f ms / %5d runs ( %8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_sample_us, n_sample, 1e-3f * ctx->state->t_sample_us / n_sample);
+        WHISPER_LOG_INFO("%s:   encode time = %8.2f ms / %5d runs ( %8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_encode_us, n_encode, 1e-3f * ctx->state->t_encode_us / n_encode);
+        WHISPER_LOG_INFO("%s:   decode time = %8.2f ms / %5d runs ( %8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_decode_us, n_decode, 1e-3f * ctx->state->t_decode_us / n_decode);
+        WHISPER_LOG_INFO("%s:   batchd time = %8.2f ms / %5d runs ( %8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_batchd_us, n_batchd, 1e-3f * ctx->state->t_batchd_us / n_batchd);
+        WHISPER_LOG_INFO("%s:   prompt time = %8.2f ms / %5d runs ( %8.2f ms per run)\n", __func__, 1e-3f * ctx->state->t_prompt_us, n_prompt, 1e-3f * ctx->state->t_prompt_us / n_prompt);
     }
     WHISPER_LOG_INFO("%s:    total time = %8.2f ms\n", __func__, (t_end_us - ctx->t_start_us)/1000.0f);
 }


### PR DESCRIPTION
When I run `scripts/bench-all.sh` on AWS c8g.xlarge, it outputs
an invalid number (`"ms"`) in the result table.

Look at the 'Encode' column in the benchmark result below:

**Running bench-all.sh (commit 6e7629b)**

```console
$ ./scripts/bench-all.sh 4 
...
|    CPU |     OS |           Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
|    --- |    --- |              --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
| <todo> | <todo> |             NEON |          tiny |   4 |   0 |  389.04 |    1.17 |    0.68 |    0.55 | 6e7629b |
| <todo> | <todo> |             NEON |          base |   4 |   0 |  879.42 |    2.05 |    1.22 |    0.98 | 6e7629b |
| <todo> | <todo> |             NEON |         small |   4 |   0 | 3290.80 |    5.45 |    3.36 |    2.82 | 6e7629b |
| <todo> | <todo> |             NEON |        medium |   4 |   0 |      ms |   14.85 |    9.51 |    8.05 | 6e7629b |
| <todo> | <todo> |             NEON |      large-v2 |   4 |   0 |      ms |   28.67 |   17.79 |   15.08 | 6e7629b |
| <todo> | <todo> |             NEON | large-v3-turbo |   4 |   0 |      ms |    4.95 |    3.15 |    2.70 | 6e7629b |
```

The reason is that the benchmark script [assumes that the 11th field is
a timestamp](https://github.com/ggerganov/whisper.cpp/blob/master/scripts/bench-all.sh#L71-L74), but this assumption can break when the target model
takes a longer time to process. 

This is a trivial fix for the issue, adding an explicit whitespace before
the timestamp field.

**Running bench-all.sh (commit a7cf427)**

```console
$ ./scripts/bench-all.sh 4 
...
|    CPU |     OS |           Config |         Model |  Th |  FA |    Enc. |    Dec. |    Bch5 |      PP |  Commit |
|    --- |    --- |              --- |           --- | --- | --- |     --- |     --- |     --- |     --- |     --- |
| <todo> | <todo> |             NEON |          tiny |   4 |   0 |  389.81 |    1.22 |    0.70 |    0.56 | a7cf427 |
| <todo> | <todo> |             NEON |          base |   4 |   0 |  883.28 |    2.12 |    1.25 |    0.99 | a7cf427 |
| <todo> | <todo> |             NEON |         small |   4 |   0 | 3302.36 |    5.61 |    3.43 |    2.86 | a7cf427 |
| <todo> | <todo> |             NEON |        medium |   4 |   0 | 10561.90 |   15.42 |    9.71 |    8.14 | a7cf427 |
| <todo> | <todo> |             NEON |      large-v2 |   4 |   0 | 20608.38 |   29.33 |   18.36 |   15.26 | a7cf427 |
| <todo> | <todo> |             NEON | large-v3-turbo |   4 |   0 | 18801.69 |    5.10 |    3.27 |    2.73 | a7cf427 |
```
