### PR TITLE
ruby : Change homepage URI in Ruby gemspec

### DIFF
--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.1.0'
 
   #### Documentation and testing.
-  s.homepage = 'https://github.com/ggerganov/whisper.cpp'
+  s.homepage = 'https://github.com/ggml-org/whisper.cpp'
   s.rdoc_options = ['--main', 'README.md']
 
 


### PR DESCRIPTION
Hi,

This commit changes home page URI in `whispercpp.gemspec`:
`https://github.com/ggerganov/whisper.cpp` -> `https://github.com/ggml-org/whisper.cpp`

Thanks.