### PR TITLE
 feat: expose language detection probabilities to server example

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -918,12 +918,10 @@ int main(int argc, char ** argv) {
             res.set_content(ss.str(), "text/vtt");
         } else if (params.response_format == vjson_format) {
             /* try to match openai/whisper's Python format */
-            std::string results = output_str(ctx, params, pcmf32s);
-            
+            std::string results = output_str(ctx, params, pcmf32s); 
             // Get language probabilities
             std::vector<float> lang_probs(whisper_lang_max_id() + 1, 0.0f);
             const auto detected_lang_id = whisper_lang_auto_detect(ctx, 0, params.n_threads, lang_probs.data());
-            
             json jres = json{
                 {"task", params.translate ? "translate" : "transcribe"},
                 {"language", whisper_lang_str_full(whisper_full_lang_id(ctx))},
@@ -934,14 +932,12 @@ int main(int argc, char ** argv) {
                 {"detected_language_probability", lang_probs[detected_lang_id]},
                 {"language_probabilities", json::object()}
             };
-
             // Add all language probabilities
             for (int i = 0; i <= whisper_lang_max_id(); ++i) {
                 if (lang_probs[i] > 0.001f) { // Only include non-negligible probabilities
                     jres["language_probabilities"][whisper_lang_str(i)] = lang_probs[i];
                 }
             }
-
             const int n_segments = whisper_full_n_segments(ctx);
             for (int i = 0; i < n_segments; ++i)
             {

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -929,23 +929,18 @@ int main(int argc, char ** argv) {
                 {"language", whisper_lang_str_full(whisper_full_lang_id(ctx))},
                 {"duration", float(pcmf32.size())/WHISPER_SAMPLE_RATE},
                 {"text", results},
-                {"segments", json::array()}
+                {"segments", json::array()},
+                {"detected_language", whisper_lang_str_full(detected_lang_id)},
+                {"detected_language_probability", lang_probs[detected_lang_id]},
+                {"language_probabilities", json::object()}
             };
 
-            // Always include language detection info
-            json lang_info = json::object();
-            // Include the probability of the detected language
-            lang_info["probability"] = lang_probs[detected_lang_id];
-            
             // Add all language probabilities
-            json all_lang_probs = json::object();
             for (int i = 0; i <= whisper_lang_max_id(); ++i) {
                 if (lang_probs[i] > 0.001f) { // Only include non-negligible probabilities
-                    all_lang_probs[whisper_lang_str(i)] = lang_probs[i];
+                    jres["language_probabilities"][whisper_lang_str(i)] = lang_probs[i];
                 }
             }
-            lang_info["language_probabilities"] = all_lang_probs;
-            jres["language_detection"] = lang_info;
 
             const int n_segments = whisper_full_n_segments(ctx);
             for (int i = 0; i < n_segments; ++i)


### PR DESCRIPTION
**Description**:
This PR enhances the JSON API response by adding detailed language detection information when transcribing or translating audio. The changes include:

1. Language detection probabilities for the detected language
2. A comprehensive list of language probabilities for all languages with non-negligible confidence scores (>0.001)
3. Integration with Whisper's existing language detection capabilities

The new information is added under a `language_detection` field in the JSON response, containing:
- `probability`: Confidence score for the detected language
- `language_probabilities`: Map of language codes to their detection probabilities

This enhancement provides more transparency into the language detection process and can be valuable for applications requiring confidence scores in language identification.

The changes are non-breaking and only add additional information to the existing JSON response structure.

**Example Output**:
```json
{
  "task": "transcribe",
  "language": "english",
  "text": "This is the transcribed text of the audio file.",
  "language_detection": {
    "probability": 0.982,
    "language_probabilities": {
      "en": 0.982,
      "fr": 0.008,
      "es": 0.005,
      "de": 0.003
    }
  },
  "segments": [
    // ... segments array content ...
  ]
}
```

In this example:
- The main detected language (English) has a 98.2% confidence score
- Other languages with lower probabilities are also included
- Only languages with probabilities > 0.001 (0.1%) are shown
- The original JSON structure remains intact, with the new `language_detection` field added
