### PR TITLE
feat: Add no-context option to server

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -79,6 +79,7 @@ struct whisper_params {
     bool use_gpu         = true;
     bool flash_attn      = false;
     bool suppress_nst    = false;
+    bool no_context      = false;
 
     std::string language        = "en";
     std::string prompt          = "";
@@ -140,6 +141,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  --convert,                     [%-7s] Convert audio to WAV, requires ffmpeg on the server\n", sparams.ffmpeg_converter ? "true" : "false");
     fprintf(stderr, "  -sns,      --suppress-nst      [%-7s] suppress non-speech tokens\n", params.suppress_nst ? "true" : "false");
     fprintf(stderr, "  -nth N,    --no-speech-thold N [%-7.2f] no speech threshold\n",   params.no_speech_thold);
+    fprintf(stderr, "  -nc,       --no-context        [%-7s] do not use previous audio context\n", params.no_context ? "true" : "false");
     fprintf(stderr, "\n");
 }
 
@@ -186,6 +188,7 @@ bool whisper_params_parse(int argc, char ** argv, whisper_params & params, serve
         else if (arg == "-fa"   || arg == "--flash-attn")      { params.flash_attn      = true; }
         else if (arg == "-sns"  || arg == "--suppress-nst")    { params.suppress_nst    = true; }
         else if (arg == "-nth"  || arg == "--no-speech-thold") { params.no_speech_thold = std::stof(argv[++i]); }
+        else if (arg == "-nc"   || arg == "--no-context")      { params.no_context      = true; }
 
         // server params
         else if (                  arg == "--port")            { sparams.port        = std::stoi(argv[++i]); }
@@ -506,6 +509,10 @@ void get_req_parameters(const Request & req, whisper_params & params)
     {
         params.suppress_nst = parse_str_to_bool(req.get_file_value("suppress_nst").content);
     }
+    if (req.has_file("no_context"))
+    {
+        params.no_context = parse_str_to_bool(req.get_file_value("no_context").content);
+    }
 }
 
 }  // namespace
@@ -818,6 +825,7 @@ int main(int argc, char ** argv) {
 
             wparams.no_timestamps    = params.no_timestamps;
             wparams.token_timestamps = !params.no_timestamps && params.response_format == vjson_format;
+            wparams.no_context       = params.no_context;
 
             wparams.suppress_nst     = params.suppress_nst;
 


### PR DESCRIPTION
**feat: Add no-context option to server**

This PR introduces a `--no-context` flag (and corresponding HTTP parameter `no_context`) to the server example. When set to true, the server will process audio requests without using the context from previous audio segments. This is useful for scenarios where each audio chunk should be treated independently.

Changes include:
- Added `no_context` boolean field to `whisper_params`.
- Updated command-line argument parsing and usage help text.
- Modified `get_req_parameters` to handle the `no_context` parameter from requests.
- Passed the `no_context` setting to `whisper_full_params` before processing.
