### PR TITLE
Fix deprecated FFmpeg functions

### DIFF
--- a/examples/ffmpeg-transcode.cpp
+++ b/examples/ffmpeg-transcode.cpp
@@ -309,7 +309,7 @@ static int decode_audio(struct audio_buffer *audio_buf, s16 **data, int *size)
 	av_frame_free(&frame);
 	swr_free(&swr);
     //avio_context_free(); // todo?
-	avcodec_close(codec);
+	avcodec_free_context(&codec);
 	avformat_close_input(&fmt_ctx);
 	avformat_free_context(fmt_ctx);
 

--- a/examples/ffmpeg-transcode.cpp
+++ b/examples/ffmpeg-transcode.cpp
@@ -194,7 +194,7 @@ static int decode_audio(struct audio_buffer *audio_buf, s16 **data, int *size)
 	AVIOContext *avio_ctx;
 	AVStream *stream;
 	AVCodecContext *codec;
-	AVPacket packet;
+	AVPacket *packet;
 	AVFrame *frame;
 	struct SwrContext *swr;
 	u8 *avio_ctx_buffer;
@@ -279,7 +279,11 @@ static int decode_audio(struct audio_buffer *audio_buf, s16 **data, int *size)
 		return -1;
 	}
 
-	av_init_packet(&packet);
+	packet=av_packet_alloc();
+	if (!packet) {
+		LOG("Error allocating the packet\n");
+		return -1;
+	}
 	frame = av_frame_alloc();
 	if (!frame) {
         LOG("Error allocating the frame\n");
@@ -289,8 +293,8 @@ static int decode_audio(struct audio_buffer *audio_buf, s16 **data, int *size)
 	/* iterate through frames */
 	*data = NULL;
 	*size = 0;
-	while (av_read_frame(fmt_ctx, &packet) >= 0) {
-		avcodec_send_packet(codec, &packet);
+	while (av_read_frame(fmt_ctx, packet) >= 0) {
+		avcodec_send_packet(codec, packet);
 
 		err = avcodec_receive_frame(codec, frame);
 		if (err == AVERROR(EAGAIN))
@@ -301,6 +305,7 @@ static int decode_audio(struct audio_buffer *audio_buf, s16 **data, int *size)
 	/* Flush any remaining conversion buffers... */
 	convert_frame(swr, codec, frame, data, size, true);
 
+	av_packet_free(&packet);
 	av_frame_free(&frame);
 	swr_free(&swr);
     //avio_context_free(); // todo?


### PR DESCRIPTION
Warnings when building with FFmpeg support:
```
whisper.cpp/examples/ffmpeg-transcode.cpp:282:23: warning: ‘void av_init_packet(AVPacket*)’ is deprecated [-Wdeprecated-declarations]
  282 |         av_init_packet(&packet);
      |         ~~~~~~~~~~~~~~^~~~~~~~~
In file included from /usr/include/libavcodec/avcodec.h:44,
                 from whisper.cpp/examples/ffmpeg-transcode.cpp:28:
/usr/include/libavcodec/packet.h:670:6: note: declared here
  670 | void av_init_packet(AVPacket *pkt);
      |      ^~~~~~~~~~~~~~
whisper.cpp/examples/ffmpeg-transcode.cpp:307:22: warning: ‘int avcodec_close(AVCodecContext*)’ is deprecated [-Wdeprecated-declarations]
  307 |         avcodec_close(codec);
      |         ~~~~~~~~~~~~~^~~~~~~
/usr/include/libavcodec/avcodec.h:2398:5: note: declared here
 2398 | int avcodec_close(AVCodecContext *avctx);
```

Replace av_init_packet with av_packet_alloc
Replace avcodec_close with avcodec_free_context
Also add packet cleanup with av_packet_free