### PR TITLE
ggml : suppress Windows compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -214,26 +214,22 @@ if (WHISPER_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(MSVC)
+if (MSVC)
     set(MSVC_WARNING_FLAGS
-		/wd4101  # Unreferenced local variable
-		/wd4005  # Macro redefinition
-		/wd4267  # Conversion from 'size_t' to a smaller type, possible loss of data
-		/wd4244  # Conversion from one type to another type, possible loss of data
-		/wd4267  # Duplicate of 4267 above - you might want to remove this duplicate
-		/wd4305  # Truncation from 'type1' to 'type2' (often double to float)
-		/wd4996  # Function or variable may be unsafe/deprecated
+        /wd4101  # Unreferenced local variable
+        /wd4005  # Macro redefinition
+        /wd4065  # switch statement contains 'default' but no 'case' labels
+        /wd4267  # Conversion from 'size_t' to a smaller type, possible loss of data
+        /wd4244  # Conversion from one type to another type, possible loss of ata
+        /wd4805  # Unsafe mix of type
+        /wd4305  # Truncation from 'type1' to 'type2' (often double to float)
+        /wd4996  # Function or variable may be unsafe/deprecated
     )
     function(disable_msvc_warnings target_name)
         target_compile_options(${target_name} PRIVATE ${MSVC_WARNING_FLAGS})
     endfunction()
 
-    disable_msvc_warnings(ggml-base)
-    disable_msvc_warnings(ggml)
-    disable_msvc_warnings(ggml-cpu)
-
     if (WHISPER_BUILD_EXAMPLES)
-        message(STATUS "Disabling MSVC warnings for examples")
         disable_msvc_warnings(common)
         disable_msvc_warnings(common-sdl)
         disable_msvc_warnings(lsp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,3 +213,37 @@ endif ()
 if (WHISPER_BUILD_EXAMPLES)
     add_subdirectory(examples)
 endif()
+
+if(MSVC)
+    set(MSVC_WARNING_FLAGS
+		/wd4101  # Unreferenced local variable
+		/wd4005  # Macro redefinition
+		/wd4267  # Conversion from 'size_t' to a smaller type, possible loss of data
+		/wd4244  # Conversion from one type to another type, possible loss of data
+		/wd4267  # Duplicate of 4267 above - you might want to remove this duplicate
+		/wd4305  # Truncation from 'type1' to 'type2' (often double to float)
+		/wd4996  # Function or variable may be unsafe/deprecated
+    )
+    function(disable_msvc_warnings target_name)
+        target_compile_options(${target_name} PRIVATE ${MSVC_WARNING_FLAGS})
+    endfunction()
+
+    disable_msvc_warnings(ggml-base)
+    disable_msvc_warnings(ggml)
+    disable_msvc_warnings(ggml-cpu)
+
+    if (WHISPER_BUILD_EXAMPLES)
+        message(STATUS "Disabling MSVC warnings for examples")
+        disable_msvc_warnings(common)
+        disable_msvc_warnings(common-sdl)
+        disable_msvc_warnings(lsp)
+        disable_msvc_warnings(wchess-core)
+        disable_msvc_warnings(whisper-command)
+        disable_msvc_warnings(whisper-cli)
+        disable_msvc_warnings(whisper-server)
+        disable_msvc_warnings(whisper-stream)
+        disable_msvc_warnings(whisper-talk-llama)
+        disable_msvc_warnings(whisper-bench)
+        disable_msvc_warnings(quantize)
+    endif()
+endif()

--- a/ggml/CMakeLists.txt
+++ b/ggml/CMakeLists.txt
@@ -360,3 +360,18 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ggml-config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/ggml-version.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ggml)
+
+if (MSVC)
+    set(MSVC_WARNING_FLAGS
+        /wd4005  # Macro redefinition
+        /wd4244  # Conversion from one type to another type, possible loss of data
+        /wd4267  # Conversion from 'size_t' to a smaller type, possible loss of data
+    )
+    function(disable_msvc_warnings target_name)
+        target_compile_options(${target_name} PRIVATE ${MSVC_WARNING_FLAGS})
+    endfunction()
+
+    disable_msvc_warnings(ggml-base)
+    disable_msvc_warnings(ggml)
+    disable_msvc_warnings(ggml-cpu)
+endif()


### PR DESCRIPTION
This commit disables compiler warnings on window using MSVC.

The motivation for these changes is that some compilers generate
warnings for these conversion, for example Windows MSVC, and
there are quite a few of them. This makes it a little difficult to
spot new warnings that may be introduced and also can be difficult
for users/embedders of ggml where these warnings are hard to separate
from their own warnings.