### PR TITLE
ruby : add encoder begin callback related methods

### DIFF
--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -114,7 +114,6 @@ class Options
     bool "GGML_HIP_GRAPHS"
     bool "GGML_HIP_NO_VMM"
     bool "GGML_HIP_ROCWMMA_FATTN"
-    bool "GGML_HIP_UMA"
     ignored "GGML_INCLUDE_INSTALL_DIR"
     bool "GGML_KOMPUTE"
     bool "GGML_LASX"

--- a/bindings/ruby/ext/ruby_whisper.h
+++ b/bindings/ruby/ext/ruby_whisper.h
@@ -19,6 +19,7 @@ typedef struct {
   bool diarize;
   ruby_whisper_callback_container *new_segment_callback_container;
   ruby_whisper_callback_container *progress_callback_container;
+  ruby_whisper_callback_container *encoder_begin_callback_container;
   ruby_whisper_callback_container *abort_callback_container;
 } ruby_whisper_params;
 

--- a/bindings/ruby/ext/ruby_whisper_transcribe.cpp
+++ b/bindings/ruby/ext/ruby_whisper_transcribe.cpp
@@ -50,15 +50,16 @@ ruby_whisper_transcribe(int argc, VALUE *argv, VALUE self) {
     fprintf(stderr, "error: failed to open '%s' as WAV file\n", fname_inp.c_str());
     return self;
   }
-  {
-    static bool is_aborted = false; // NOTE: this should be atomic to avoid data race
+  // Commented out because it is work in progress
+  // {
+  //   static bool is_aborted = false; // NOTE: this should be atomic to avoid data race
 
-    rwp->params.encoder_begin_callback = [](struct whisper_context * /*ctx*/, struct whisper_state * /*state*/, void * user_data) {
-      bool is_aborted = *(bool*)user_data;
-      return !is_aborted;
-    };
-    rwp->params.encoder_begin_callback_user_data = &is_aborted;
-  }
+  //   rwp->params.encoder_begin_callback = [](struct whisper_context * /*ctx*/, struct whisper_state * /*state*/, void * user_data) {
+  //     bool is_aborted = *(bool*)user_data;
+  //     return !is_aborted;
+  //   };
+  //   rwp->params.encoder_begin_callback_user_data = &is_aborted;
+  // }
 
   register_callbacks(rwp, &self);
 

--- a/bindings/ruby/lib/whisper/model/uri.rb
+++ b/bindings/ruby/lib/whisper/model/uri.rb
@@ -53,7 +53,7 @@ module Whisper
           http.request request do |response|
             case response
             when Net::HTTPNotModified
-            # noop
+              # noop
             when Net::HTTPOK
               download response
             when Net::HTTPRedirection
@@ -68,7 +68,7 @@ module Whisper
       rescue => err
         if cache_path.exist?
           warn err
-        # Use cache file
+          # Use cache file
         else
           raise
         end

--- a/bindings/ruby/sig/whisper.rbs
+++ b/bindings/ruby/sig/whisper.rbs
@@ -7,6 +7,7 @@ module Whisper
   type log_callback = ^(Integer level, String message, Object user_data) -> void
   type new_segment_callback = ^(Whisper::Context, void, Integer n_new, Object user_data) -> void
   type progress_callback = ^(Whisper::Context, void, Integer progress, Object user_data) -> void
+  type encoder_begin_callback = ^(Whisper::Context, void, Object user_data) -> void
   type abort_callback = ^(Whisper::Context, void, Object user_data) -> boolish
 
   LOG_LEVEL_NONE: Integer
@@ -146,6 +147,8 @@ module Whisper
       ?new_segment_callback_user_data: Object,
       ?progress_callback: progress_callback,
       ?progress_callback_user_data: Object,
+      ?encoder_begin_callback: encoder_begin_callback,
+      ?encoder_begin_callback_user_data: Object,
       ?abort_callback: abort_callback,
       ?abort_callback_user_data: Object
     ) -> instance
@@ -306,6 +309,18 @@ module Whisper
 
     def progress_callback_user_data: () -> Object
 
+    # Sets encoder begin callback, called when the encoder starts.
+    #
+    def encoder_begin_callback=: (encoder_begin_callback) -> encoder_begin_callback
+
+    def encoder_begin_callback: () -> (encoder_begin_callback | nil)
+
+    # Sets user data passed to the last argument of encoder begin callback.
+    #
+    def encoder_begin_callback_user_data=: (Object) -> Object
+
+    def encoder_begin_callback_user_data: () -> Object
+
     # Sets abort callback, called to check if the process should be aborted.
     #
     #   params.abort_callback = ->(user_data) {
@@ -334,6 +349,10 @@ module Whisper
     # Hook called on progress update. Yields each progress Integer between 0 and 100.
     #
     def on_progress: { (Integer progress) -> void } -> void
+
+    # Hook called on encoder starts.
+    #
+    def on_encoder_begin: { () -> void } -> void
 
     # Call block to determine whether abort or not. Return +true+ when you want to abort.
     #

--- a/bindings/ruby/tests/helper.rb
+++ b/bindings/ruby/tests/helper.rb
@@ -6,9 +6,9 @@ class TestBase < Test::Unit::TestCase
   AUDIO = File.join(__dir__, "..", "..", "..", "samples", "jfk.wav")
 
   class << self
-    attr_reader :whisper
+    def whisper
+      return @whisper if @whisper
 
-    def startup
       @whisper = Whisper::Context.new("base.en")
       params = Whisper::Params.new
       params.print_timestamps = false

--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name    = "whispercpp"
   s.authors = ["Georgi Gerganov", "Todd A. Fisher"]
   s.version = '1.3.2'
-  s.date    = '2025-04-17'
+  s.date    = '2025-04-25'
   s.description = %q{High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model via Ruby}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.md']


### PR DESCRIPTION
Hi,

This pull request adds encoder begin callback related methods to Ruby bindings. I commend out existing abort mechanism because it is work in progress and I don't have idea how to implement it.

Thank you.