### PR TITLE
examples : add missing cstdint include to llama-mmap.h

### DIFF
--- a/examples/talk-llama/llama-mmap.h
+++ b/examples/talk-llama/llama-mmap.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <vector>
+#include <cstdint>
 
 struct llama_file;
 struct llama_mmap;


### PR DESCRIPTION
This commit adds an include for cstdint to talk-llama.

The motivation for this is that currently this is causing an compiler error and failing the CI build:
```console
In file included from D:/a/whisper.cpp/whisper.cpp/examples/talk-llama/llama-mmap.cpp:1:
D:/a/whisper.cpp/whisper.cpp/examples/talk-llama/llama-mmap.h:26:5:
error: 'uint32_t' does not name a type
   26 |     uint32_t read_u32() const;
      |     ^~~~~~~~
```

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/14700142155/job/41248102108