### PR TITLE
server : add --no-gpu option to print usage output

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -142,6 +142,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  -sns,      --suppress-nst      [%-7s] suppress non-speech tokens\n", params.suppress_nst ? "true" : "false");
     fprintf(stderr, "  -nth N,    --no-speech-thold N [%-7.2f] no speech threshold\n",   params.no_speech_thold);
     fprintf(stderr, "  -nc,       --no-context        [%-7s] do not use previous audio context\n", params.no_context ? "true" : "false");
+    fprintf(stderr, "  -ng,       --no-gpu            [%-7s] do not use gpu\n", params.use_gpu ? "false" : "true");
     fprintf(stderr, "\n");
 }
 


### PR DESCRIPTION
This commit adds the the command line option `--no-gpu` to the server examples print usage function.

The motivation for this is that this options is available and can be set but it is not displayed in the usage message.

Refs: https://github.com/ggml-org/whisper.cpp/issues/3095