### PR TITLE
ruby : refine HTTP cache feature

### DIFF
--- a/bindings/ruby/lib/whisper/model/uri.rb
+++ b/bindings/ruby/lib/whisper/model/uri.rb
@@ -55,6 +55,8 @@ module Whisper
             when Net::HTTPNotModified
               # noop
             when Net::HTTPOK
+              return if !response.key?("last-modified") && cache_path.exist?
+
               download response
             when Net::HTTPRedirection
               request URI(response["location"]), headers

--- a/bindings/ruby/tests/test_whisper.rb
+++ b/bindings/ruby/tests/test_whisper.rb
@@ -118,18 +118,7 @@ class TestWhisper < TestBase
     dev = StringIO.new("")
     $stderr = dev
     Whisper::Context.new("base.en")
-
-    # Filter out any lines starting with "Downloading" or containing only dots.
-    # The reason for this is that I think the recent migration to Huggingface
-    # Xet might have changed the downloading behavior. There is now a redirect
-    # to a different URL, which causes the download to be retried even if the
-    # file is already downloaded.
-    # TODO(danbev) Remove this when a proper fix is in place.
-    filtered_output = dev.string.lines.reject do |line|
-      line.start_with?("Downloading") || line.strip =~ /^\.+$/
-    end.join
-
-    assert_empty filtered_output, "Expected no output, but got: #{filtered_output.inspect}"
+    assert_empty dev.string
   ensure
     $stderr = stderr
   end

--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name    = "whispercpp"
   s.authors = ["Georgi Gerganov", "Todd A. Fisher"]
   s.version = '1.3.2'
-  s.date    = '2025-04-25'
+  s.date    = '2025-05-01'
   s.description = %q{High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model via Ruby}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.md']


### PR DESCRIPTION
Hi,

Now Hugging Face doesn't support if-modified-since field. Because Ruby's caching feature for model files have relied on it, now it downloads model files for every access. This pull request refine the logic of caching and reduce downloads.

refs: #3106