### PR TITLE
ci : add zip extension to xcframework artifact name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -964,7 +964,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework.zip
-          name: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework
+          name: whisper-${{ needs.determine-tag.outputs.tag_name }}-xcframework.zip
 
   android:
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||


### PR DESCRIPTION
This commit add the .zip extension to the xcframework artifact name in the GitHub Actions workflow.

The motivation for this that the release job will look for .zip files and will not find the xcframework artifact without the extension, and hence will not upload it to the release.