### PR TITLE
ruby : omit test_build_options locally

### DIFF
--- a/bindings/ruby/tests/test_package.rb
+++ b/bindings/ruby/tests/test_package.rb
@@ -37,6 +37,11 @@ class TestPackage < TestBase
   end
 
   def test_build_options
+    # This test is disabled as it currently fails when run locally on macOS and
+    # Linux. We need to find a good way to handle the situation with build
+    # options which varies between platforms.
+    # Refs: https://github.com/ggml-org/whisper.cpp/pull/3132
+    omit "Temporarily disabled locally as this test currently fails when run locally" unless ENV["CI"]
     options = BuildOptions::Options.new
     assert_empty options.missing_options
     unless ENV["CI"]


### PR DESCRIPTION
ruby : omit test_build_options locally
    
This commit omits the test for `test_build_options` when run locally as
it currently fails on Linux and MacOS platforms.

The motivation for this change is that currently when running the tests
locally on a non-macOS platform the test fails with the following error:
```console
    .F
    ========================================================================
    Failure: test_build_options(TestPackage):
      <["ACCELERATE_FRAMEWORK",
       "CMAKE_OSX_ARCHITECTURES",
       "CMAKE_OSX_SYSROOT",
       "FOUNDATION_LIBRARY",
       "METALKIT_FRAMEWORK",
       "METAL_FRAMEWORK"]> was expected to be empty.
    /home/danbev/work/ai/whisper.cpp/bindings/ruby/tests/test_package.rb:43:in `test_build_options'
         40:     options = BuildOptions::Options.new
         41:     assert_empty options.missing_options
         42:     unless ENV["CI"]
      => 43:       assert_empty options.extra_options
         44:     end
         45:   end
         46: end
    ========================================================================
```