### PR TITLE
ruby : test extra build options only when env var specified

### DIFF
--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -53,7 +53,7 @@ class Options
   end
 
   def extra_options
-    @options.keys + @pending_options - @ignored_options -
+    @options.keys + @pending_options + @ignored_options -
       cmake_options.collect {|name, type, value| name}
   end
 

--- a/bindings/ruby/tests/test_package.rb
+++ b/bindings/ruby/tests/test_package.rb
@@ -39,7 +39,7 @@ class TestPackage < TestBase
   def test_build_options
     options = BuildOptions::Options.new
     assert_empty options.missing_options
-    if ENV["TEST_EXTRA_OPTIONS"]
+    if ENV["TEST_EXTRA_OPTIONS"] == "1"
       assert_empty options.extra_options
     end
   end

--- a/bindings/ruby/tests/test_package.rb
+++ b/bindings/ruby/tests/test_package.rb
@@ -37,14 +37,9 @@ class TestPackage < TestBase
   end
 
   def test_build_options
-    # This test is disabled as it currently fails when run locally on macOS and
-    # Linux. We need to find a good way to handle the situation with build
-    # options which varies between platforms.
-    # Refs: https://github.com/ggml-org/whisper.cpp/pull/3132
-    omit "Temporarily disabled locally as this test currently fails when run locally" unless ENV["CI"]
     options = BuildOptions::Options.new
     assert_empty options.missing_options
-    unless ENV["CI"]
+    if ENV["TEST_EXTRA_OPTIONS"]
       assert_empty options.extra_options
     end
   end

--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name    = "whispercpp"
   s.authors = ["Georgi Gerganov", "Todd A. Fisher"]
   s.version = '1.3.2'
-  s.date    = '2025-05-01'
+  s.date    = '2025-05-11'
   s.description = %q{High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model via Ruby}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.md']


### PR DESCRIPTION
As said in #3132, switch `TEXT_EXTRA_OPTIONS` is added. This is intended to be used by Ruby bindings' maintainer (@KitaitiMakoto) on local machine.