### PR TITLE
Update Readme to recommend same Openvino as Python tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ This can result in significant speedup in encoder performance. Here are the inst
 
 - Build `whisper.cpp` with OpenVINO support:
 
-  Download OpenVINO package from [release page](https://github.com/openvinotoolkit/openvino/releases). The recommended version to use is [2023.0.0](https://github.com/openvinotoolkit/openvino/releases/tag/2023.0.0).
+  Download OpenVINO package from [release page](https://github.com/openvinotoolkit/openvino/releases). The recommended version to use is [2024.6.0](https://github.com/openvinotoolkit/openvino/releases/tag/2024.6.0). Ready to use Binaries of the required libraries can be found in the [OpenVino Archives](https://storage.openvinotoolkit.org/repositories/openvino/packages/2024.6/)
 
   After downloading & extracting package onto your development system, set up required environment by sourcing setupvars script. For example:
 


### PR DESCRIPTION
Today I noticed that Python was using OpenVINO 2024.6.0 in the script models/convert-whisper-to-openvino.py

I did a build with 2024.6.0 and - voila - OpenVINO versions were readable by whisper-cli

Prior to noticing this OpenVINO has never worked (as I've used 2023.0.0 as told) I also tried current a while ago - don't think that worked either

I also Added a pointer to the binary archives

I researched the issue and provided a close but wrong answer in #3105 - might be worthwhile creating a README.openvino once I've done test builds on other platforms