### PR TITLE
examples : update link to Paul Tol's color scheme [no ci]

### DIFF
--- a/examples/common.h
+++ b/examples/common.h
@@ -283,7 +283,7 @@ static std::string set_xterm256_foreground(int r, int g, int b) {
 }
 
 // Lowest is red, middle is yellow, highest is green. Color scheme from
-// Paul Tol; it is colorblind friendly https://personal.sron.nl/~pault/
+// Paul Tol; it is colorblind friendly https://sronpersonalpages.nl/~pault
 const std::vector<std::string> k_colors = {
     set_xterm256_foreground(220,   5,  12),
     set_xterm256_foreground(232,  96,  28),


### PR DESCRIPTION
This commit updates the link to Paul Tol's color scheme in the `examples/common.h` file. The previous link was outdated and pointed to a non-existent page.