### PR TITLE
cli : print color scheme info for --print-colors

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -1081,6 +1081,9 @@ int main(int argc, char ** argv) {
                     params.tinydiarize ? "tdrz = 1, " : "",
                     params.no_timestamps ? 0 : 1);
 
+            if (params.print_colors) {
+                fprintf(stderr, "%s: color scheme: red (low confidence), yellow (medium), green (high confidence)\n", __func__);
+            }
             fprintf(stderr, "\n");
         }
 


### PR DESCRIPTION
This commit adds a description of the color scheme used in the CLI when the --print-colors option is enabled.

The motivation for this is that it is not immediately clear what the color scheme is when using the CLI with the --print-colors option.

Example output:
```console
$ ./build/bin/whisper-cli -f samples/jfk.wav --print-colors
...

main: color scheme: red (low confidence), yellow (medium), green (high confidence)

[00:00:00.000 --> 00:00:11.000]   And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.
```
The description will not be dispayed if the `--no-prints` options is set.

Refs: https://github.com/ggml-org/whisper.cpp/issues/3135