### PR TITLE
Allow Vino + CoreML files to be in different directories, also optional switch to disable coreml for testing

### DIFF
--- a/examples/bench/bench.cpp
+++ b/examples/bench/bench.cpp
@@ -61,7 +61,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "                           %-7s  2 - ggml_mul_mat\n",                            "");
     fprintf(stderr, "  -ng,      --no-gpu      [%-7s] disable GPU\n",                                 params.use_gpu ? "false" : "true");
     fprintf(stderr, "  -fa,      --flash-attn  [%-7s] enable flash attention\n",                      params.flash_attn ? "true" : "false");
-    fprintf(stderr, "  -ml,      --disable-ml  [%-7s] disable CoreML\n");
+    fprintf(stderr, "  -ml,      --disable-ml  [%-7s] disable CoreML\n",                              params.disable_coreml ? "true" : "false");
     fprintf(stderr, "  -l        --coreml      [%-7s] Set CoreML Directory\n",                        params.coreml_dir.c_str());
     fprintf(stderr, "  -v        --openvino    [%-7s] Set OpenVINO Directory\n",                      params.openvino_dir.c_str());
     fprintf(stderr, "\n");
@@ -75,11 +75,15 @@ static int whisper_bench_full(const whisper_params & params) {
     // whisper init
 
     struct whisper_context_params cparams = whisper_context_default_params();
+    char * sptr1 = nullptr;
+    char * sptr2 = nullptr;
 
     cparams.use_gpu    = params.use_gpu;
     cparams.flash_attn = params.flash_attn;
-    cparams.path_openvino = string_to_ptr(params.openvino_dir);
-    cparams.path_coreml = string_to_ptr(params.coreml_dir);
+    sptr1 = string_to_ptr(params.coreml_dir);
+    cparams.path_openvino = sptr1;
+    sptr2 = string_to_ptr(params.openvino_dir);
+    cparams.path_coreml = sptr2;
     cparams.disable_coreml = params.disable_coreml;
     
     struct whisper_context * ctx = whisper_init_from_file_with_params(params.model.c_str(), cparams);
@@ -154,6 +158,8 @@ static int whisper_bench_full(const whisper_params & params) {
     }
 
     whisper_print_timings(ctx);
+    free(sptr2);
+    free(sptr1);
     whisper_free(ctx);
 
     fprintf(stderr, "\n");

--- a/examples/bench/bench.cpp
+++ b/examples/bench/bench.cpp
@@ -34,7 +34,7 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-l"  || arg == "--coreml")     { params.coreml_dir = argv[++i]; }
         else if (arg == "-v"  || arg == "--openvino")   { params.openvino_dir = argv[++i]; }
         else if (arg == "-w"  || arg == "--what")       { params.what       = atoi(argv[++i]); }
-        else if (arg == "-ml" || arg == "--disable-coreml") { params.disable_coreml = true; }
+        else if (arg == "-ml" || arg == "--disable-ml") { params.disable_coreml = true; }
         else if (arg == "-ng" || arg == "--no-gpu")     { params.use_gpu    = false; }
         else if (arg == "-fa" || arg == "--flash-attn") { params.flash_attn = true; }
         else {
@@ -61,9 +61,9 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "                           %-7s  2 - ggml_mul_mat\n",                            "");
     fprintf(stderr, "  -ng,      --no-gpu      [%-7s] disable GPU\n",                                 params.use_gpu ? "false" : "true");
     fprintf(stderr, "  -fa,      --flash-attn  [%-7s] enable flash attention\n",                      params.flash_attn ? "true" : "false");
-    fprintf(stderr, "  -ml,      --disable-coreml     disable CoreML\n");
-    fprintf(stderr, "  -l        --coreml             Set CoreML Directory\n");
-    fprintf(stderr, "  -v        --openvino           Set OpenVINO Directory\n");
+    fprintf(stderr, "  -ml,      --disable-ml  [%-7s] disable CoreML\n");
+    fprintf(stderr, "  -l        --coreml      [%-7s] Set CoreML Directory\n",                        params.coreml_dir.c_str());
+    fprintf(stderr, "  -v        --openvino    [%-7s] Set OpenVINO Directory\n",                      params.openvino_dir.c_str());
     fprintf(stderr, "\n");
 }
 

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -907,6 +907,8 @@ int main(int argc, char ** argv) {
 #endif
 
     whisper_params params;
+    char * sptr1 = nullptr;
+    char * sptr2 = nullptr;
 
     // If the only argument starts with "@", read arguments line-by-line
     // from the given file.
@@ -983,8 +985,10 @@ int main(int argc, char ** argv) {
 
     cparams.use_gpu    = params.use_gpu;
     cparams.flash_attn = params.flash_attn;
-    cparams.path_coreml = string_to_ptr(params.coreml_directory);
-    cparams.path_openvino = string_to_ptr(params.openvino_directory);
+    sptr1 = string_to_ptr(params.coreml_directory);
+    cparams.path_coreml = sptr1;
+    sptr2 = string_to_ptr(params.openvino_directory);
+    cparams.path_openvino = sptr2;
     cparams.disable_coreml = params.disable_coreml;
     
     if (!params.dtw.empty()) {
@@ -1279,6 +1283,9 @@ int main(int argc, char ** argv) {
     if (!params.no_prints) {
         whisper_print_timings(ctx);
     }
+    free(sptr2);
+    free(sptr1);
+    
     whisper_free(ctx);
 
     return 0;

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -273,7 +273,8 @@ static void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params
     fprintf(stderr, "  -f FNAME,  --file FNAME        [%-7s] input audio file path\n",                            "");
     fprintf(stderr, "  -oved D,   --ov-e-device DNAME [%-7s] the OpenVINO device used for encode inference\n",  params.openvino_encode_device.c_str());
     fprintf(stderr, "  -dov DN,   --ov-directory DN   [%-7s] the OpenVINO directory path\n",                    params.openvino_directory.c_str());
-    fprintf(stderr, "  -nlml,     --disable-coreml           Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
+    fprintf(stderr, "  -nlml,     --disable-coreml    [%-7s] Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
+    fprintf(stderr, "  -nlml,     --disable-coreml    [%-7s] Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
     fprintf(stderr, "  -dtw MODEL --dtw MODEL         [%-7s] compute token-level timestamps\n",                 params.dtw.c_str());
     fprintf(stderr, "  -ls,       --log-score         [%-7s] log best decoder scores of tokens\n",              params.log_score?"true":"false");
     fprintf(stderr, "  -ng,       --no-gpu            [%-7s] disable GPU\n",                                    params.use_gpu ? "false" : "true");

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -273,8 +273,7 @@ static void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params
     fprintf(stderr, "  -f FNAME,  --file FNAME        [%-7s] input audio file path\n",                            "");
     fprintf(stderr, "  -oved D,   --ov-e-device DNAME [%-7s] the OpenVINO device used for encode inference\n",  params.openvino_encode_device.c_str());
     fprintf(stderr, "  -dov DN,   --ov-directory DN   [%-7s] the OpenVINO directory path\n",                    params.openvino_directory.c_str());
-    fprintf(stderr, "  -nlml,     --disable-coreml    [%-7s] Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
-    fprintf(stderr, "  -nlml,     --disable-coreml    [%-7s] Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
+    fprintf(stderr, "  -noml,     --disable-coreml    [%-7s] Disable CoreML\n",                                 params.disable_coreml ? "true" : "false");
     fprintf(stderr, "  -dtw MODEL --dtw MODEL         [%-7s] compute token-level timestamps\n",                 params.dtw.c_str());
     fprintf(stderr, "  -ls,       --log-score         [%-7s] log best decoder scores of tokens\n",              params.log_score?"true":"false");
     fprintf(stderr, "  -ng,       --no-gpu            [%-7s] disable GPU\n",                                    params.use_gpu ? "false" : "true");

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -125,6 +125,12 @@ extern "C" {
         int dtw_n_top;
         struct whisper_aheads dtw_aheads;
 
+        // Allow coreml + openvino files to have their own directories
+        // Purposely not ifdef'd
+        char * path_coreml;
+        char * path_openvino;
+        bool disable_coreml;
+
         size_t dtw_mem_size; // TODO: remove
     };
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3707,9 +3707,6 @@ struct whisper_context_params whisper_context_default_params() {
     return result;
 }
 
-//    std::string path_coreml; // populated by whisper_init_from_file_with_params()
-//    std::string path_openvino; // populated by whisper_init_from_file_with_params()
-
 struct whisper_context * whisper_init_from_file_with_params_no_state(const char * path_model, struct whisper_context_params params) {
     WHISPER_LOG_INFO("%s: loading model from '%s'\n", __func__, path_model);
 #ifdef _MSC_VER

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -37,8 +37,6 @@
 #include <vector>
 #include <sys/stat.h> // For data_file_exists
 
-#define NDEBUG
-
 #if defined(WHISPER_BIG_ENDIAN)
 template<typename T>
 static T byteswap(T value) {
@@ -3358,9 +3356,7 @@ static std::string replace_extra_data_directory(std::string path_bin, std::strin
     
     // Check  replacement_path actually exists
     if(must_exist && !data_file_exists(new_path.c_str())) {
-        #ifdef NDEBUG
         fprintf(stderr, "Trying to replace with non-existant path %s returning passed path %s\n", replacement_path.c_str(), path_bin.c_str());
-        #endif
         return path_bin;
     }
     
@@ -3385,9 +3381,7 @@ static std::string replace_extra_data_directory(std::string path_bin, std::strin
     new_path = new_path + file_part;
     
     if(must_exist && !data_file_exists(new_path.c_str())) {
-        #ifdef NDEBUG
         fprintf(stderr, "Error replacing path %s returning passed path %s\n", replacement_path.c_str(), path_bin.c_str());
-        #endif
         return path_bin;
     }
 


### PR DESCRIPTION
All the data files live in one directory - this gets confusing and hard to manage

This PR enables the openvino and coreml data files to be in other places than the same location as the main model

The parameters may be passed via whisper_context_params as path_coreml and path_openvino. If these are not supplied the current normal all-in-one-place scheme remains but if passed then these directories can be anywhere.

Also I added a disable_coreml parameter. This allows you to build with coreml but disable it on demand - useful for testing and debugging. This is a very simple bypass that merely skips over the coreml init function which has the same practical effect of not having coreml at all