### PR TITLE
whisper : add build_*/ to .gitignore [no ci]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 build/
 build-*/
+build_*/
 
 # SPM
 .build/


### PR DESCRIPTION
This commit add `build_*/` to `.gitignore` to ignore all build directories that start with `build_`.

The motivation for this is that the Go bindings creates a directory named build_go, which is not ignored by the current .gitignore. I was not sure if changing this to build-go could effect exising users so I opted to update .gitignore instead.