### PR TITLE
vad : return early if no vad segments are detected

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6735,6 +6735,9 @@ int whisper_full_with_state(
             WHISPER_LOG_ERROR("%s: failed to compute VAD\n", __func__);
             return -1;
         }
+        if (vad_n_samples == 0) {
+            return 0;
+        }
         process_samples = vad_samples.data();
         n_process_samples = vad_n_samples;
     }


### PR DESCRIPTION
This commit adds a check to `whisper_full_with_state` and if no VAD segments are detected, the function will return early.

The motivation for this is that if no VAD segments are detected, the function will not have any samples to process which can happen if an audio sample does not contain any speech. I did not test this previously and only discovered this when updating the stream example.