### PR TITLE
ruby : add GGML_SYCL_DNN option to ruby bindings

### DIFF
--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -149,6 +149,7 @@ class Options
     bool "GGML_SYCL_F16"
     bool "GGML_SYCL_GRAPH"
     string "GGML_SYCL_TARGET"
+    bool "GGML_SYCL_DNN"
     bool "GGML_VULKAN"
     bool "GGML_VULKAN_CHECK_RESULTS"
     bool "GGML_VULKAN_DEBUG"


### PR DESCRIPTION
This commit adds the `GGML_SYCL_DNN` option to the Ruby bindings for the GGML library. This option as added to ggml in
Commit (5e7e07758a5f3172380500e173ca71f679bbef1e "sycl: use oneDNN for matrices multiplication")

The motivation for this change to enable the CI build to pass.