### PR TITLE
ci : use dynamic libopenblas.dll for window-blas

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -703,7 +703,7 @@ jobs:
                 github.event.inputs.pre_release_tag != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: whisper-blas-bin-${{ matrix.arch }}.zip
+          name: whisper-blas-bin-${{ matrix.arch }}
           path: whisper-blas-bin-${{ matrix.arch }}.zip
 
   windows-cublas:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -692,19 +692,14 @@ jobs:
         if: matrix.sdl2 == 'ON'
         run: copy "$env:SDL2_DIR/../lib/${{ matrix.s2arc }}/SDL2.dll" build/bin/${{ matrix.build }}
 
-      - name: Pack bin artifacts
-        shell: pwsh
-        run: |
-              Compress-Archive -Path "build/bin/${{ matrix.build }}" -DestinationPath "whisper-blas-bin-${{ matrix.arch }}.zip"
-
       - name: Upload binaries
         if: matrix.blas == 'ON' && matrix.sdl2 == 'ON' && ${{ (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
                 github.event.inputs.create_release == 'true' ||
                 github.event.inputs.pre_release_tag != '' }}
         uses: actions/upload-artifact@v4
         with:
-          name: whisper-blas-bin-${{ matrix.arch }}
-          path: whisper-blas-bin-${{ matrix.arch }}.zip
+          name: whisper-blas-bin-${{ matrix.arch }}.zip
+          path: "build/bin/${{ matrix.build }}/**"
 
   windows-cublas:
     if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' ||

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -629,11 +629,14 @@ jobs:
         arch: [Win32, x64]
         blas: [ON]
         sdl2: [ON]
+        blasver: [0.3.29]
         include:
           - arch: Win32
             s2arc: x86
+            blasfile: x86
           - arch: x64
             s2arc: x64
+            blasfile: x64_64
           - sdl2: ON
             s2ver: 2.28.5
 
@@ -654,7 +657,8 @@ jobs:
       - name: Install OpenBLAS and pkgconfiglite
         if: matrix.blas == 'ON'
         run: |
-          vcpkg install --triplet=${{ matrix.s2arc }}-windows openblas
+          Invoke-WebRequest "https://github.com/OpenMathLib/OpenBLAS/releases/download/v${{matrix.blasver}}/OpenBLAS-${{matrix.blasver}}_${{matrix.blasfile}}.zip" -OutFile "OpenBLAS-${{matrix.blasver}}.zip"
+          Expand-Archive "OpenBLAS-${{matrix.blasver}}.zip" -DestinationPath "OpenBLAS-${{matrix.blasver}}"
           choco install pkgconfiglite
 
       - name: Fetch SDL2 and set SDL2_DIR
@@ -671,6 +675,8 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
           -DGGML_BLAS=${{ matrix.blas }}
           -DGGML_BLAS_VENDOR=OpenBLAS
+          -DBLAS_LIBRARIES="$env:GITHUB_WORKSPACE/OpenBLAS-${{matrix.blasver}}/lib/libopenblas.lib"
+          -DBLAS_INCLUDE_DIRS="$env:GITHUB_WORKSPACE/OpenBLAS-${{matrix.blasver}}/include"
           -DWHISPER_SDL2=${{ matrix.sdl2 }}
 
       - name: Build
@@ -680,7 +686,7 @@ jobs:
 
       - name: Copy openblas.dll
         if: matrix.blas == 'ON'
-        run: copy "C:/vcpkg/packages/openblas_${{ matrix.s2arc }}-windows/bin/openblas.dll" build/bin/${{ matrix.build }}
+        run: copy "$env:GITHUB_WORKSPACE/OpenBLAS-${{matrix.blasver}}/bin/libopenblas.dll" build/bin/${{ matrix.build }}
 
       - name: Copy SDL2.dll
         if: matrix.sdl2 == 'ON'


### PR DESCRIPTION
This commit updates the windows-blas job to use the dynamic (can load different kernels depending of the CPU arch) libopenblas.dll instead of the "static" openblas.dll that get installed by vcpgk.

The motivation for this change is that there have been reports of performance drops in later version specifically related to blas. Please see the links below for more details.

Resolves: https://github.com/ggml-org/whisper.cpp/issues/3166
Refs: https://github.com/ggml-org/whisper.cpp/issues/2666#issuecomment-2885978811