### PR TITLE
whisper : remove redundant assignments

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -8397,12 +8397,6 @@ static void whisper_exp_compute_token_level_timestamps(
 
         const int64_t tt = t_beg + 2*(token.tid - whisper_token_beg(&ctx));
 
-        tokens[j].id    = token.id;
-        tokens[j].tid   = token.tid;
-        tokens[j].p     = token.p;
-        tokens[j].pt    = token.pt;
-        tokens[j].ptsum = token.ptsum;
-
         tokens[j].vlen = voice_length(whisper_token_to_str(&ctx, token.id));
 
         if (token.pt > thold_pt && token.ptsum > thold_ptsum && token.tid > tid_last && tt <= t1) {


### PR DESCRIPTION
This commit removes some redundant assignments in the function `whisper_exp_compute_token_level_timestamps`.

The motivations for this is that tokens[j] and token are references to the same object and this can be a little confusing when reading the code.