### PR TITLE
node : enable no_prints to suppress all output

### DIFF
--- a/examples/addon.node/addon.cpp
+++ b/examples/addon.node/addon.cpp
@@ -82,7 +82,7 @@ void whisper_print_segment_callback(struct whisper_context * ctx, struct whisper
             t1 = whisper_full_get_segment_t1(ctx, i);
         }
 
-        if (!params.no_timestamps) {
+        if (!params.no_timestamps && !params.no_prints) {
             printf("[%s --> %s]  ", to_timestamp(t0).c_str(), to_timestamp(t1).c_str());
         }
 
@@ -113,12 +113,14 @@ void whisper_print_segment_callback(struct whisper_context * ctx, struct whisper
 
         // colorful print bug
         //
-        const char * text = whisper_full_get_segment_text(ctx, i);
-        printf("%s%s", speaker.c_str(), text);
+        if (!params.no_prints) {
+            const char * text = whisper_full_get_segment_text(ctx, i);
+            printf("%s%s", speaker.c_str(), text);
+        }
 
 
         // with timestamps or speakers: each segment on new line
-        if (!params.no_timestamps || params.diarize) {
+        if ((!params.no_timestamps || params.diarize) && !params.no_prints) {
             printf("\n");
         }
 


### PR DESCRIPTION
This commit enable the node addon to suppress all output, even the result of the transcription if the no_prints parameter is set to true.

The motivation for this is that for the node addon there is a fullfilment handler/success callback to process the transcription result. And it might be useful to be able to disable the printing of the transcription result to the console, so that the user can handle the result in their own way.

Refs: https://github.com/ggml-org/whisper.cpp/issues/3176