### PR TITLE
node : add language detection support

### DIFF
--- a/examples/addon.node/__test__/whisper.spec.js
+++ b/examples/addon.node/__test__/whisper.spec.js
@@ -17,6 +17,7 @@ const whisperParamsMock = {
   comma_in_time: false,
   translate: true,
   no_timestamps: false,
+  detect_language: false,
   audio_ctx: 0,
   max_len: 0,
   prompt: "",
@@ -30,8 +31,9 @@ const whisperParamsMock = {
 describe("Run whisper.node", () => {
     test("it should receive a non-empty value", async () => {
         let result = await whisperAsync(whisperParamsMock);
+      console.log(result);
 
-        expect(result.length).toBeGreaterThan(0);
+        expect(result['transcription'].length).toBeGreaterThan(0);
     }, 10000);
 });
 

--- a/examples/addon.node/index.js
+++ b/examples/addon.node/index.js
@@ -17,6 +17,7 @@ const whisperParams = {
   comma_in_time: false,
   translate: true,
   no_timestamps: false,
+  detect_language: false,
   audio_ctx: 0,
   max_len: 0,
   progress_callback: (progress) => {
@@ -31,6 +32,8 @@ const params = Object.fromEntries(
       const [key, value] = item.slice(2).split("=");
       if (key === "audio_ctx") {
         whisperParams[key] = parseInt(value);
+      } else if (key === "detect_language") {
+        whisperParams[key] = value === "true";
       } else {
         whisperParams[key] = value;
       }


### PR DESCRIPTION
This commit add support for language detection in the Whisper Node.js addon example.

The motivation for this is that currently there does not seem to be a way to get the language detected by whisper.

Examples usage:
```console
$ node examples/addon.node/index.js --language='en' \
    --model='models/ggml-base.bin' \
    --fname_inp='samples/jfk.wav' \
    --detect_language=true
whisperParams = {
  language: 'en',
  model: 'models/ggml-base.bin',
  fname_inp: 'samples/jfk.wav',
  use_gpu: true,
  flash_attn: false,
  no_prints: true,
  comma_in_time: false,
  translate: true,
  no_timestamps: false,
  detect_language: true,
  audio_ctx: 0,
  max_len: 0,
  progress_callback: [Function: progress_callback]
}

{ language: 'en' }
```

And if the `language` option is set to "auto":
```console
{
  language: 'en',
  transcription: [
    [
      '00:00:00.000',
      '00:00:07.600',
      ' And so my fellow Americans, ask not what your country can do for you,'
    ],
    [
      '00:00:07.600',
      '00:00:10.600',
      ' ask what you can do for your country.'
    ]
  ]
}
```