### PR TITLE
Improve GGML_BACKEND_DL install in Linux

### DIFF
--- a/ggml/src/CMakeLists.txt
+++ b/ggml/src/CMakeLists.txt
@@ -224,7 +224,10 @@ function(ggml_add_backend_library backend)
         set_target_properties(${backend} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
         target_compile_definitions(${backend} PRIVATE GGML_BACKEND_DL)
         add_dependencies(ggml ${backend})
-        install(TARGETS ${backend} LIBRARY DESTINATION bin)
+        install(TARGETS ${backend}
+            RUNTIME DESTINATION bin
+            ARCHIVE DESTINATION lib
+            LIBRARY DESTINATION lib)
    else()
         add_library(${backend} ${ARGN})
         target_link_libraries(ggml PUBLIC ${backend})


### PR DESCRIPTION
Small alteration I forgot to push for #3195

This PR makes the Linux install when GGML_BACKEND_DL is defined act the same way as whisper's install does 
i.e. in Linux shared objects -> lib (same location as whisper.so ends up)
On Windows, however, the dlls end up in bin (where they belong for Win)

Note that owing to #1240 this may still require attention