### PR TITLE
ggml : Fix backtrace breaking Windows build

### DIFF
--- a/ggml/src/ggml.c
+++ b/ggml/src/ggml.c
@@ -200,7 +200,7 @@ void ggml_print_backtrace(void) {
     }
 }
 #else
-static void ggml_print_backtrace(void) {
+void ggml_print_backtrace(void) {
     // platform not supported
 }
 #endif


### PR DESCRIPTION
@ggerganov Sorry I missed the second definition.

Fixes: https://github.com/ggml-org/ggml/pull/1232#issuecomment-2918566270