### PR TITLE
whisper-cli : align token timestamps with VAD ts

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -727,7 +727,13 @@ static void output_json(
                                 value_s("text", whisper_token_to_str(ctx, token.id), false);
                                 if(token.t0 > -1 && token.t1 > -1) {
                                     // If we have per-token timestamps, write them out
-                                    times_o(token.t0, token.t1, false);
+                                    if (params.vad) {
+                                        times_o(vad_ts_to_original_ts(token.t0, ctx),
+                                                vad_ts_to_original_ts(token.t1, ctx),
+                                                false);
+                                    } else {
+                                        times_o(token.t0, token.t1, false);
+                                    }
                                 }
                                 value_i("id", token.id, false);
                                 value_f("p", token.p, false);

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -712,6 +712,8 @@ extern "C" {
     WHISPER_API float whisper_vad_segments_get_segment_t0(struct whisper_vad_segments * segments, int i_segment);
     WHISPER_API float whisper_vad_segments_get_segment_t1(struct whisper_vad_segments * segments, int i_segment);
 
+    WHISPER_API int64_t vad_ts_to_original_ts(int64_t vad_ts, struct whisper_context * ctx);
+
     WHISPER_API void whisper_vad_free_segments(struct whisper_vad_segments * segments);
     WHISPER_API void whisper_vad_free         (struct whisper_vad_context  * ctx);
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7968,6 +7968,10 @@ int64_t whisper_full_get_segment_t1(struct whisper_context * ctx, int i_segment)
     return whisper_full_get_segment_t1_from_state(ctx->state, i_segment);
 }
 
+int64_t vad_ts_to_original_ts(int64_t vad_ts, struct whisper_context * ctx) {
+    return map_processed_to_original_time(vad_ts, ctx->state->vad_mapping_table);
+}
+
 bool whisper_full_get_segment_speaker_turn_next_from_state(struct whisper_state * state, int i_segment) {
     return state->result_all[i_segment].speaker_turn_next;
 }


### PR DESCRIPTION
This commit aligns the token timestamps with the VAD timestamps when VAD is enabled.

The motivation of this is that currently the token timestamps that are reported in the full json output are the timestamps that whisper sees after the VAD has processed the audio. This means that whisper only sees possibly filtered audio and the token timestamps are related to the filtered audio, not the original audio. For the segment timestamps we map/align them with original timestamps but this is not currenly done for the token timestamps which is what this commit aims to address.

Resolves: https://github.com/ggml-org/whisper.cpp/issues/3174

----
Example of token level timestamps prior to this PR:
```console
$ ./build/bin/whisper-cli -m models/ggml-medium.en.bin -f samples/gb1.ogg --vad -vm models/for-tests-silero-v5.1.2-ggml.bin -ojf -of gb1
...
[00:00:00.990 --> 00:00:07.800]   My fellow Americans, this day has brought terrible news and great sadness to our country.
[00:00:07.800 --> 00:00:15.860]   At 9 o'clock this morning, Mission Control in Houston lost contact with our space shuttle
...

  "transcription": [                                                            
    {                                                                           
      "timestamps": {                                                           
        "from": "00:00:00,990",                                                 
        "to": "00:00:07,800"                                                    
      },                                                                        
      "offsets": {                                                              
        "from": 990,                                                            
        "to": 7800                                                              
      },                                                                        
      "text": " My fellow Americans, this day has brought terrible news and great sadness to our country.",
      "tokens": [                                                               
        {                                                                       
          "text": "[_BEG_]",                                                    
          "timestamps": {                                                       
            "from": "00:00:00,000",                                             
            "to": "00:00:00,000"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 0,                                                          
            "to": 0                                                             
          },                                                                    
          "id": 50363,                                                          
          "p": 0.994401,                                                        
          "t_dtw": -1                                                           
        },                                                                      
        {                                                                       
          "text": " My",                                                        
          "timestamps": {                                                       
            "from": "00:00:00,020",                                             
            "to": "00:00:00,100"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 20,                                                         
            "to": 100                                                           
          },                                                                    
          "id": 2011,                                                           
          "p": 0.883255,                                                        
          "t_dtw": -1                                                           
        },                                                                      
        {                                                                       
          "text": " fellow",                                                    
          "timestamps": {                                                       
            "from": "00:00:00,170",                                             
            "to": "00:00:00,610"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 170,                                                        
            "to": 610                                                           
          },                                                                    
          "id": 5891,                                                           
          "p": 0.989602,                                                        
          "t_dtw": -1                                                           
        },                      
        ....
```
And with this PR:
```console
[00:00:00.990 --> 00:00:07.800]   My fellow Americans, this day has brought terrible news and great sadness to our country.
[00:00:07.800 --> 00:00:15.860]   At 9 o'clock this morning, Mission Control in Houston lost contact with our space shuttle
[00:00:15.860 --> 00:00:18.510]   Columbia.
...
  "transcription": [                                                            
    {                                                                           
      "timestamps": {                                                           
        "from": "00:00:00,990",                                                 
        "to": "00:00:07,800"                                                    
      },                                                                        
      "offsets": {                                                              
        "from": 990,                                                            
        "to": 7800                                                              
      },                                                                        
      "text": " My fellow Americans, this day has brought terrible news and great sadness to our country.",
      "tokens": [                                                               
        {                                                                       
          "text": "[_BEG_]",                                                    
          "timestamps": {                                                       
            "from": "00:00:00,990",                                             
            "to": "00:00:00,990"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 990,                                                        
            "to": 990                                                           
          },                                                                    
          "id": 50363,                                                          
          "p": 0.994401,                                                        
          "t_dtw": -1                                                           
        },                                                                      
        {                                                                       
          "text": " My",                                                        
          "timestamps": {                                                       
            "from": "00:00:01,000",                                             
            "to": "00:00:01,080"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 1000,                                                       
            "to": 1080                                                          
          },                                                                    
          "id": 2011,                                                           
          "p": 0.883255,                                                        
          "t_dtw": -1                                                           
        },                                                                      
        {                                                                       
          "text": " fellow",                                                    
          "timestamps": {                                                       
            "from": "00:00:01,140",                                             
            "to": "00:00:01,540"                                                
          },                                                                    
          "offsets": {                                                          
            "from": 1140,                                                       
            "to": 1540                                                          
          },                                                                    
          "id": 5891,                                                           
          "p": 0.989602,                                                        
          "t_dtw": -1                                                           
        },                  
```