### PR TITLE
ci : switch to HTTPS mirrors for Ubuntu 22.04

### DIFF
--- a/.devops/main.Dockerfile
+++ b/.devops/main.Dockerfile
@@ -1,19 +1,31 @@
 FROM ubuntu:22.04 AS build
 WORKDIR /app
 
+# Set non-interactive frontend and install ca-certificates first
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-  apt-get install -y build-essential wget cmake git \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+    apt-get install -y ca-certificates && \
+    sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list && \
+    sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y build-essential wget cmake git \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-COPY .. .
+COPY . .
 RUN make base.en
 
 FROM ubuntu:22.04 AS runtime
 WORKDIR /app
 
+# Set non-interactive frontend and install ca-certificates first
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-  apt-get install -y curl ffmpeg libsdl2-dev wget cmake git \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+    apt-get install -y ca-certificates && \
+    sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list && \
+    sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y curl ffmpeg libsdl2-dev wget cmake git \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY --from=build /app /app
 ENV PATH=/app/build/bin:$PATH

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,9 @@ jobs:
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
 
+            apt-get update
+            apt-get install -y ca-certificates
+
             # Switch to HTTPS mirrors
             sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
             sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
 
             apt-get update
             apt-get install -y ca-certificates
@@ -137,6 +138,15 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
             apt update
             apt install -y build-essential libsdl2-dev cmake git
             cmake -B build -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a
@@ -165,6 +175,15 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
+
             apt update
             apt install -y build-essential libsdl2-dev cmake git
             cmake -B build -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv7-a+fp
@@ -250,6 +269,14 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
             apt update
             apt install -y build-essential cmake libsdl2-dev git
             cmake . -DWHISPER_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }}
@@ -280,6 +307,14 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
             apt update
             apt install -y build-essential cmake libsdl2-dev git
             cmake . -DWHISPER_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv8-a
@@ -310,6 +345,15 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
+
             apt update
             apt install -y build-essential cmake libsdl2-dev git
             cmake . -DWHISPER_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DGGML_NATIVE=OFF -DGGML_CPU_ARM_ARCH=armv7-a+fp
@@ -343,6 +387,15 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
+
             apt update
             apt install -y clang build-essential cmake libsdl2-dev git
             cmake . -DWHISPER_SDL2=ON -DCMAKE_BUILD_TYPE=${{ matrix.build }} -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang
@@ -373,6 +426,15 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+            export DEBIAN_FRONTEND=noninteractive
+
+            apt-get update
+            apt-get install -y ca-certificates
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
+
             apt update
             apt install -y build-essential cmake git
             cmake . -DCMAKE_BUILD_TYPE=Debug \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,11 @@ jobs:
             -v ${{ github.workspace }}:/workspace \
             -w /workspace ${{ env.ubuntu_image }} /bin/sh -c '
             set -e
+
+            # Switch to HTTPS mirrors
+            sed -i "s|http://archive.ubuntu.com|https://archive.ubuntu.com|g" /etc/apt/sources.list
+            sed -i "s|http://security.ubuntu.com|https://security.ubuntu.com|g" /etc/apt/sources.list
+
             apt update
             apt install -y build-essential libsdl2-dev cmake git
             cmake -B build


### PR DESCRIPTION
This commit is an attempt to resolve the issue with the Ubuntu 22.04 GitHub Actions runner that fails to download packages from HTTP mirrors.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/15384056535/job/43291948394?pr=3217