### PR TITLE
get_rows & dequantize function implementation for repacked weights of type q4_0 (q4_0x8)

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1437,26 +1437,39 @@ static bool weight_buft_supported(const whisper_hparams & hparams, ggml_tensor *
         // GPU and default CPU backend support all operators
         op_supported = true;
     } else {
+        ggml_init_params params = {
+            /*.mem_size   =*/ 2 * ggml_tensor_overhead(),
+            /*.mem_buffer =*/ nullptr,
+            /*.no_alloc   =*/ true,
+        };
+
+        ggml_context_ptr ctx_ptr { ggml_init(params) };
+        if (!ctx_ptr) {
+            throw std::runtime_error("failed to create ggml context");
+        }
+        ggml_context * ctx = ctx_ptr.get();
+
+        ggml_tensor * op_tensor = nullptr;
+        
+        int64_t n_ctx = hparams.n_audio_ctx;
+
         switch (op) {
-            // The current extra_buffer_type implementations only support GGML_OP_MUL_MAT
+            // The current extra_buffer_type implementations only support GGML_OP_MUL_MAT & GGML_OP_GET_ROWS (q4_0)
             case GGML_OP_MUL_MAT: {
-                ggml_init_params params = {
-                    /*.mem_size   =*/ 2 * ggml_tensor_overhead(),
-                    /*.mem_buffer =*/ nullptr,
-                    /*.no_alloc   =*/ true,
-                };
-
-                ggml_context_ptr ctx_ptr { ggml_init(params) };
-                if (!ctx_ptr) {
-                    throw std::runtime_error("failed to create ggml context");
-                }
-                ggml_context * ctx = ctx_ptr.get();
-
-                ggml_tensor * op_tensor = nullptr;
-
-                int64_t n_ctx = hparams.n_audio_ctx;
                 ggml_tensor * b = ggml_new_tensor_4d(ctx, GGML_TYPE_F32, w->ne[0], n_ctx, w->ne[2], w->ne[3]);
                 op_tensor = ggml_mul_mat(ctx, w, b);
+
+                // create a temporary dummy buffer for the weight so that supports_op can check the buffer type
+                GGML_ASSERT(w->buffer == nullptr);
+                w->buffer = ggml_backend_buft_alloc_buffer(buft, 0);
+                op_supported = ggml_backend_dev_supports_op(dev, op_tensor);
+                ggml_backend_buffer_free(w->buffer);
+                w->buffer = nullptr;
+                break;
+            }
+            case GGML_OP_GET_ROWS: {
+                ggml_tensor * b = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_ctx);
+                op_tensor = ggml_get_rows(ctx, w, b);
 
                 // create a temporary dummy buffer for the weight so that supports_op can check the buffer type
                 GGML_ASSERT(w->buffer == nullptr);


### PR DESCRIPTION
- This implements the GGML_OP_GET_ROWS operation specifically for repacked (block interleaved) 4-bit quantized format (q4_0x8) defined within ggml-cpu-aarch64.cpp

- The following gains were observed by the changes made in the PR - The changes allow for increased usage of the GEMM function (ggml_gemm_q4_0_8x8_q8_0) for q4_0 type defined within ggml-cpu-aarch64.cpp

![image](https://github.com/user-attachments/assets/05520026-236d-4c0f-8d65-b586a317f9fb)

master branch commit - [82f461eaa4e6a1ba29fc0dbdaa415a9934ee8a1d](https://github.com/ggml-org/whisper.cpp/commit/82f461eaa4e6a1ba29fc0dbdaa415a9934ee8a1d)
development (get_rows) branch commit - [d6cc466bd48dd27474ecb00c3baba2e8a887f6c4](https://github.com/swetha097/whisper.cpp/commit/d6cc466bd48dd27474ecb00c3baba2e8a887f6c4)

The PR was tested in AMD Raphael 7600X which supports the following flags :

> system_info: n_threads = 4 / 12 | WHISPER : COREML = 0 | OPENVINO = 0 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1 | LLAMAFILE = 1 | OPENMP = 1 | AARCH64_REPACK = 1 |  

Model for performance tests Downloaded from : https://huggingface.co/ggerganov/whisper.cpp/blob/main/ggml-base.en.bin and quantized to q4_0

This patch of the code was also tested with llama.cpp repository & the perplexity of Q4_0 models were ensured to be the same before and after the changes made : 

> Final estimate: PPL = 5.9625 +/- 0.03348

Model used for perplexity test quantized from -  https://huggingface.co/meta-llama/Llama-2-7b




























































