### PR TITLE
fix compilation with MSVC for arm64 with __ARM_NEON defined 

### DIFF
--- a/ggml/src/ggml-cpu/ggml-cpu-impl.h
+++ b/ggml/src/ggml-cpu/ggml-cpu-impl.h
@@ -81,7 +81,7 @@ struct ggml_compute_params {
 #define ggml_vld1q_u32(w,x,y,z) { (w), (x), (y), (z) }
 #endif // _MSC_VER
 
-#if !defined(__aarch64__)
+#if !defined(__aarch64__) && !defined(_MSC_VER)
 
 // 32-bit ARM compatibility
 

--- a/ggml/src/ggml-impl.h
+++ b/ggml/src/ggml-impl.h
@@ -326,7 +326,7 @@ GGML_API void ggml_aligned_free(void * ptr, size_t size);
 // for old CUDA compilers (<= 11), we use uint16_t: ref https://github.com/ggml-org/llama.cpp/pull/10616
 // for     MUSA compilers        , we use uint16_t: ref https://github.com/ggml-org/llama.cpp/pull/11843
 //
-#if defined(__ARM_NEON) && !(defined(__CUDACC__) && __CUDACC_VER_MAJOR__ <= 11) && !defined(__MUSACC__)
+#if defined(__ARM_NEON) && !(defined(__CUDACC__) && __CUDACC_VER_MAJOR__ <= 11) && !defined(__MUSACC__) && !defined(_MSC_VER)
     #define GGML_COMPUTE_FP16_TO_FP32(x) ggml_compute_fp16_to_fp32(x)
     #define GGML_COMPUTE_FP32_TO_FP16(x) ggml_compute_fp32_to_fp16(x)
 


### PR DESCRIPTION
These 2 commits fix compilation errors when trying to build with MSVC arm64 with __ARM_NEON defined