### PR TITLE
ruby : add cleaning of library names in dependencies

### DIFF
--- a/bindings/ruby/ext/dependencies.rb
+++ b/bindings/ruby/ext/dependencies.rb
@@ -17,7 +17,12 @@ class Dependencies
   def libs
     tsort.filter_map {|node|
       label, shape = @nodes[node]
-      shape == @static_lib_shape ? label : nil
+      if shape == @static_lib_shape
+        clean_label = label.gsub(/\\n\([^)]+\)/, '').gsub(/[^a-zA-Z0-9_-]/, '-')
+        clean_label
+      else
+        nil
+      end
     }.reverse.collect {|lib| "lib#{lib}.a"}
   end
 


### PR DESCRIPTION
This commit adds a cleaning step to the library names in the `Dependencies` class of the Ruby bindings.

The motivation for this is that with the introduction of a library name alias for ggml in Commit (b933d17c306e800b6d919e3ee895219c3f64d5cd "Add in-build ggml::ggml ALIAS library (ggml/1260)) causes the Makefile generation to break:
```console
$ sed -n '165,170p' ext/Makefile
CLEANOBJS     = $(OBJS) *.bak
TARGET_SO_DIR_TIMESTAMP = $(TIMESTAMP_DIR)/.sitearchdir.time
$(TARGET_SO): libcommon.a libwhisper.a libggml\n(ggml::ggml).a libggml-cpu.a libggml-base.a
libcommon.a libwhisper.a libggml\n(ggml::ggml).a libggml-cpu.a libggml-base.a: cmake-targets
cmake-targets:
	/usr/bin/cmake -S sources -B build -D BUILD_SHARED_LIBS=OFF -D CMAKE_ARCHIVE_OUTPUT_DIRECTORY=/home/danbev/work/ai/whisper.cpp/bindings/ruby/ext -D CMAKE_POSITION_INDEPENDENT_CODE=ON
```