### PR TITLE
ci : update windows runner to windows-2022

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -922,7 +922,6 @@ jobs:
 
       - name: Build Project
         shell: cmd
-        env:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cmake --version


### PR DESCRIPTION
This commit changes the windows-2019 runner to windows-2022.

The motiation for this is that the windows-2019 runner is scheduled for deprection and will be removed 2025-06-30. There are currently "burnout" periods that started 2025-06-01 and during these times jobs with windows-2019 will fails which has happened lately on our CI.

Refs: https://github.com/actions/runner-images/issues/12045