### PR TITLE
ruby : add .gitignore entries for ext directory

### DIFF
--- a/bindings/ruby/.gitignore
+++ b/bindings/ruby/.gitignore
@@ -1,3 +1,8 @@
 LICENSE
 pkg/
 lib/whisper.*
+ext/examples/
+ext/ggml/
+ext/include/
+ext/scripts/
+ext/src/


### PR DESCRIPTION
This commit adds entries to `.gitignore` for directories in the `ext` directory.

The motivation for this is that currently after building locally these following files are reported by git as untracked:
```console
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	ext/examples/
	ext/ggml/
	ext/include/
	ext/scripts/
	ext/src/
```