### PR TITLE
backport CoreML features to macos < 14

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -58,6 +58,7 @@ if (WHISPER_COREML)
     set(TARGET whisper.coreml)
 
     add_library(${TARGET}
+        coreml/whisper-compat.m
         coreml/whisper-encoder.h
         coreml/whisper-encoder.mm
         coreml/whisper-encoder-impl.h
@@ -76,6 +77,7 @@ if (WHISPER_COREML)
         COMPILE_FLAGS "-fobjc-arc"
         XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
         )
+
     set_target_properties(${TARGET} PROPERTIES FOLDER "libs")
 endif()
 

--- a/src/coreml/whisper-compat.h
+++ b/src/coreml/whisper-compat.h
@@ -1,0 +1,10 @@
+#import <CoreML/CoreML.h>
+
+@interface MLModel (Compat)
+- (void) predictionFromFeatures:(id<MLFeatureProvider>) input
+              completionHandler:(void (^)(id<MLFeatureProvider> output, NSError * error)) completionHandler;
+
+- (void) predictionFromFeatures:(id<MLFeatureProvider>) input
+                        options:(MLPredictionOptions *) options
+              completionHandler:(void (^)(id<MLFeatureProvider> output, NSError * error)) completionHandler;
+@end

--- a/src/coreml/whisper-compat.m
+++ b/src/coreml/whisper-compat.m
@@ -1,0 +1,35 @@
+#import "whisper-compat.h"
+#import <Foundation/Foundation.h>
+
+@implementation MLModel (Compat)
+
+#if !defined(MAC_OS_X_VERSION_14_00) || MAC_OS_X_VERSION_MAX_ALLOWED < MAC_OS_X_VERSION_14_00
+
+- (void) predictionFromFeatures:(id<MLFeatureProvider>) input
+              completionHandler:(void (^)(id<MLFeatureProvider> output, NSError * error)) completionHandler {
+    [NSOperationQueue.new addOperationWithBlock:^{
+        NSError *error = nil;
+        id<MLFeatureProvider> prediction = [self predictionFromFeatures:input error:&error];
+
+        [NSOperationQueue.mainQueue addOperationWithBlock:^{
+            completionHandler(prediction, error);
+        }];
+    }];
+}
+
+- (void) predictionFromFeatures:(id<MLFeatureProvider>) input
+                        options:(MLPredictionOptions *) options
+              completionHandler:(void (^)(id<MLFeatureProvider> output, NSError * error)) completionHandler {
+    [NSOperationQueue.new addOperationWithBlock:^{
+        NSError *error = nil;
+        id<MLFeatureProvider> prediction = [self predictionFromFeatures:input options:options error:&error];
+
+        [NSOperationQueue.mainQueue addOperationWithBlock:^{
+            completionHandler(prediction, error);
+        }];
+    }];
+}
+
+#endif
+
+@end

--- a/src/coreml/whisper-decoder-impl.m
+++ b/src/coreml/whisper-decoder-impl.m
@@ -8,6 +8,7 @@
 #error This file must be compiled with automatic reference counting enabled (-fobjc-arc)
 #endif
 
+#import "whisper-compat.h"
 #import "whisper-decoder-impl.h"
 
 @implementation whisper_decoder_implInput

--- a/src/coreml/whisper-encoder-impl.m
+++ b/src/coreml/whisper-encoder-impl.m
@@ -8,6 +8,7 @@
 #error This file must be compiled with automatic reference counting enabled (-fobjc-arc)
 #endif
 
+#import "whisper-compat.h"
 #import "whisper-encoder-impl.h"
 
 @implementation whisper_encoder_implInput


### PR DESCRIPTION
i'm on 12.7 and `[MLModel predictionFromFeatures:]` versions with completion handler are [only available on macos 14](https://developer.apple.com/documentation/coreml/mlmodel/predictionfromfeatures:completionhandler:?language=objc) which is a little too cutting edge for me.

before this i'd get:
```
whisper-encoder-impl.m:183:17: error: no visible @interface for 'MLModel'
declares the selector 'predictionFromFeatures:completionHandler:'
    [self.model predictionFromFeatures:input completionHandler:^(id<MLFeatureProvider> prediction, NSError *predictionError) {
     ~~~~~~~~~~ ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```