### PR TITLE
examples : set the C++ standard to C++17 for server

### DIFF
--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(TARGET whisper-server)
 add_executable(${TARGET} server.cpp httplib.h)
 


### PR DESCRIPTION
This commit updates the server example to use C++17 as the standard.

The motivation for this change is that currently the ci-run `ggml-100-mac-m4` is failing when compiling the server example on macOS. The `talk-llama` example also has this setting so it looks like an alright change to make.

ggml-ci

Refs: https://github.com/ggml-org/ci/tree/results/whisper.cpp/2a/4d6db7d90899aff3d58d70996916968e4e0d27/ggml-100-mac-m4