### PR TITLE
whisper : clear result_all if vad_samples is empty

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7724,6 +7724,7 @@ int whisper_full(
             return -1;
         }
         if (vad_samples.empty()) {
+            ctx->state->result_all.clear();
             return 0;
         }
         samples = vad_samples.data();


### PR DESCRIPTION
This commit clears the results_all vector no VAD segments are found.
    
The motivation for this is that this would normally be done by
`whisper_full_with_state` but when no VAD segments are detected this
current implementation does not call that function and hence the vector
does not get reset. This can lead to issues in applications like the
server example where it will incorrectly process the old results.
    
Resolves: https://github.com/ggml-org/whisper.cpp/issues/3250