### PR TITLE
android : update CMakeLists.txt to use FetchContent for ggml

### DIFF
--- a/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
@@ -14,33 +14,9 @@ set(
     ${CMAKE_SOURCE_DIR}/jni.c
     )
 
-# TODO: this needs to be updated to work with the new ggml CMakeLists
-
-if (NOT GGML_HOME)
-    set(
-        SOURCE_FILES
-        ${SOURCE_FILES}
-        ${WHISPER_LIB_DIR}/ggml/src/ggml.c
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-alloc.c
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-backend.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-backend-reg.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-quants.c
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-threading.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ggml-cpu.c
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ggml-cpu.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/hbm.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/traits.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/unary-ops.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/binary-ops.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/vec.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/ops.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/arch/arm/quants.c
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/arch/arm/repack.cpp
-        ${WHISPER_LIB_DIR}/ggml/src/ggml-cpu/quants.c
-        )
-endif()
-
 find_library(LOG_LIB log)
+
+include(FetchContent)
 
 function(build_library target_name)
     add_library(
@@ -70,15 +46,13 @@ function(build_library target_name)
     endif ()
 
     if (GGML_HOME)
-        include(FetchContent)
         FetchContent_Declare(ggml SOURCE_DIR ${GGML_HOME})
-        FetchContent_MakeAvailable(ggml)
-
-        target_compile_options(ggml PRIVATE ${GGML_COMPILE_OPTIONS})
-        target_link_libraries(${target_name} ${LOG_LIB} android ggml)
     else()
-        target_link_libraries(${target_name} ${LOG_LIB} android)
+        FetchContent_Declare(ggml SOURCE_DIR ${WHISPER_LIB_DIR}/ggml)
     endif()
+    FetchContent_MakeAvailable(ggml)
+    target_compile_options(ggml PRIVATE ${GGML_COMPILE_OPTIONS})
+    target_link_libraries(${target_name} ${LOG_LIB} android ggml)
 
 
 endfunction()


### PR DESCRIPTION
This commit updates the CMakeLists.txt file for the Android Whisper example to use FetchContent for managing the ggml library.

The motivation for this change is avoid having to make manual changes to the CMakeLists.txt file after syncing the ggml library.

I've built and run the example locally to verify that it works as expected.

Refs: https://github.com/ggml-org/whisper.cpp/pull/3265#issuecomment-2986715717