### PR TITLE
ruby : specify Apple frameworks explicitly on build

### DIFF
--- a/bindings/ruby/.gitignore
+++ b/bindings/ruby/.gitignore
@@ -6,3 +6,4 @@ ext/ggml/
 ext/include/
 ext/scripts/
 ext/src/
+test/fixtures/

--- a/bindings/ruby/Rakefile
+++ b/bindings/ruby/Rakefile
@@ -69,6 +69,21 @@ CLEAN.include LIB_FILE
 
 Rake::TestTask.new
 
+TEST_FIXTURE_AUDIO = "test/fixtures/jfk.wav"
+TEST_FIXTURE_AUDIO_SRC = File.expand_path(File.join(__dir__, "..", "..", "samples", "jfk.wav"))
+TEST_FIXTURE_AUDIO_DIR = TEST_FIXTURE_AUDIO.pathmap("%d")
+directory TEST_FIXTURE_AUDIO_DIR
+if File.exist? TEST_FIXTURE_AUDIO_SRC
+  file TEST_FIXTURE_AUDIO => [TEST_FIXTURE_AUDIO_SRC, TEST_FIXTURE_AUDIO_DIR] do |t|
+    symlink t.source, t.name
+  end
+else
+  require "open-uri"
+  file TEST_FIXTURE_AUDIO => TEST_FIXTURE_AUDIO_DIR do |t|
+    File.write t.name, URI("https://github.com/ggml-org/whisper.cpp/raw/refs/heads/master/samples/jfk.wav").read
+  end
+end
+
 TEST_MEMORY_VIEW = "test/jfk_reader/jfk_reader.#{RbConfig::CONFIG['DLEXT']}"
 file TEST_MEMORY_VIEW => "test/jfk_reader/jfk_reader.c" do |t|
   chdir "test/jfk_reader" do
@@ -76,6 +91,6 @@ file TEST_MEMORY_VIEW => "test/jfk_reader/jfk_reader.c" do |t|
     sh "make"
   end
 end
-CLEAN.include "test/jfk_reader/jfk_reader.{o,#{RbConfig::CONFIG['DLEXT']}}"
+CLEAN.include TEST_MEMORY_VIEW
 
-task test: [LIB_FILE, TEST_MEMORY_VIEW]
+task test: [LIB_FILE, TEST_MEMORY_VIEW, TEST_FIXTURE_AUDIO]

--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -50,7 +50,9 @@ class Options
 
   # See ggml/src/ggml-cpu/CMakeLists.txt
   def configure_accelerate
-    $LDFLAGS << " -framework Accelerate" if enabled?("GGML_ACCELERATE")
+    if RUBY_PLATFORM.match?(/darwin/) && enabled?("GGML_ACCELERATE")
+      $LDFLAGS << " -framework Accelerate"
+    end
   end
 
   # See ggml/src/ggml-metal/CMakeLists.txt

--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -43,7 +43,29 @@ class Options
       @options[name] = [type, value]
     end
 
+    configure_accelerate
+    configure_metal
     configure_coreml
+  end
+
+  # See ggml/src/ggml-cpu/CMakeLists.txt
+  def configure_accelerate
+    use_accelerate = if @options["GGML_ACCELERATE"][1].nil?
+                       cmake_options["GGML_ACCELERATE"][1]
+                     else
+                       @options["GGML_ACCELERATE"][1]
+                     end
+    $LDFLAGS << " -framework Accelerate" if use_accelerate
+  end
+
+  # See ggml/src/ggml-metal/CMakeLists.txt
+  def configure_metal
+    use_metal = if @options["GGML_METAL"][1].nil?
+                  cmake_options["GGML_METAL"][1]
+                else
+                  @options["GGML_METAL"][1]
+                end
+    $LDFLAGS << " -framework Foundation -framework Metal -framework MetalKit" if use_metal
   end
 
   def configure_coreml

--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -58,8 +58,12 @@ class Options
     $LDFLAGS << " -framework Foundation -framework Metal -framework MetalKit" if enabled?("GGML_METAL")
   end
 
+  # See src/CmakeLists.txt
   def configure_coreml
-    $CPPFLAGS << " -DRUBY_WHISPER_USE_COREML" if enabled?("WHISPER_COREML")
+    if enabled?("WHISPER_COREML")
+      $LDFLAGS << " -framework Foundation -framework CoreML"
+      $CPPFLAGS << " -DRUBY_WHISPER_USE_COREML"
+    end
   end
 
   def option_name(name)

--- a/bindings/ruby/ext/options.rb
+++ b/bindings/ruby/ext/options.rb
@@ -50,34 +50,27 @@ class Options
 
   # See ggml/src/ggml-cpu/CMakeLists.txt
   def configure_accelerate
-    use_accelerate = if @options["GGML_ACCELERATE"][1].nil?
-                       cmake_options["GGML_ACCELERATE"][1]
-                     else
-                       @options["GGML_ACCELERATE"][1]
-                     end
-    $LDFLAGS << " -framework Accelerate" if use_accelerate
+    $LDFLAGS << " -framework Accelerate" if enabled?("GGML_ACCELERATE")
   end
 
   # See ggml/src/ggml-metal/CMakeLists.txt
   def configure_metal
-    use_metal = if @options["GGML_METAL"][1].nil?
-                  cmake_options["GGML_METAL"][1]
-                else
-                  @options["GGML_METAL"][1]
-                end
-    $LDFLAGS << " -framework Foundation -framework Metal -framework MetalKit" if use_metal
+    $LDFLAGS << " -framework Foundation -framework Metal -framework MetalKit" if enabled?("GGML_METAL")
   end
 
   def configure_coreml
-    use_coreml = if @options["WHISPER_COREML"][1].nil?
-                   cmake_options["WHISPER_COREML"][1]
-                 else
-                   @options["WHISPER_COREML"][1]
-                 end
-    $CPPFLAGS << " -DRUBY_WHISPER_USE_COREML" if use_coreml
+    $CPPFLAGS << " -DRUBY_WHISPER_USE_COREML" if enabled?("WHISPER_COREML")
   end
 
   def option_name(name)
     name.downcase.gsub("_", "-")
+  end
+
+  def enabled?(option)
+    if @options[option][1].nil?
+      cmake_options[option][1]
+    else
+      @options[option][1]
+    end
   end
 end

--- a/bindings/ruby/lib/whisper/model/uri.rb
+++ b/bindings/ruby/lib/whisper/model/uri.rb
@@ -132,13 +132,13 @@ module Whisper
 
     class ZipURI < URI
       def cache
-        zip_path = Pathname(super)
+        zip_path = super
         dest = unzipped_path
         return if dest.exist? && dest.mtime >= zip_path.mtime
         escaping dest do
           system "unzip", "-q", "-d", zip_path.dirname.to_path, zip_path.to_path, exception: true
         end
-        zip_path.to_path
+        zip_path
       end
 
       def clear_cache

--- a/bindings/ruby/sig/whisper.rbs
+++ b/bindings/ruby/sig/whisper.rbs
@@ -412,7 +412,7 @@ module Whisper
     end
 
     class ZipURI < URI
-      def cache: () -> String
+      def cache: () -> Pathname
       def clear_cache: () -> void
     end
   end

--- a/bindings/ruby/test/helper.rb
+++ b/bindings/ruby/test/helper.rb
@@ -3,7 +3,7 @@ require "whisper"
 require_relative "jfk_reader/jfk_reader"
 
 class TestBase < Test::Unit::TestCase
-  AUDIO = File.join(__dir__, "..", "..", "..", "samples", "jfk.wav")
+  AUDIO = File.join(__dir__, "fixtures", "jfk.wav")
 
   class << self
     def whisper

--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -4,7 +4,6 @@ Gem::Specification.new do |s|
   s.name    = "whispercpp"
   s.authors = ["Georgi Gerganov", "Todd A. Fisher"]
   s.version = '1.3.3'
-  s.date    = '2025-06-10'
   s.description = %q{High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model via Ruby}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.md']


### PR DESCRIPTION
Fixes #3259