### PR TITLE
ci : add apt-get clean to musa Dockerfile

### DIFF
--- a/.devops/main-musa.Dockerfile
+++ b/.devops/main-musa.Dockerfile
@@ -10,8 +10,9 @@ FROM ${BASE_MUSA_DEV_CONTAINER} AS build
 WORKDIR /app
 
 RUN apt-get update && \
-    apt-get install -y build-essential libsdl2-dev wget cmake git \
-    && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+    apt-get install -y build-essential libsdl2-dev wget cmake git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* /var/tmp/*
 
 COPY .. .
 # Enable muBLAS
@@ -21,8 +22,9 @@ FROM ${BASE_MUSA_RUN_CONTAINER} AS runtime
 WORKDIR /app
 
 RUN apt-get update && \
-  apt-get install -y curl ffmpeg wget cmake git \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+    apt-get install -y curl ffmpeg wget cmake git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* /var/tmp/*
 
 COPY --from=build /app /app
 ENV PATH=/app/build/bin:$PATH


### PR DESCRIPTION
This commit adds `apt-get clean` to the musa Dockerfile to reduce the image size by removing cached package files after installation.

The motivation for this is to try to reduce the size of the Docker image and see if this can avoid the "no space left on device" error during the CI build process.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/15815324254