### PR TITLE
chore: add .gitignore entries for OpenVINO support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ extra/bench-gg.txt
 models/*.mlmodel
 models/*.mlmodelc
 models/*.mlpackage
+models/*-encoder-openvino.xml
+models/*-encoder-openvino-cache/
 bindings/java/.gradle/
 bindings/java/.idea/
 .idea/


### PR DESCRIPTION
Add `.gitignore` entries for OpenVINO support.  
This eliminates unexpected diffs when using OpenVINO.

```gitignore
# added
models/*-encoder-openvino.xml
models/*-encoder-openvino-cache/
```

for

https://github.com/ggml-org/whisper.cpp/blob/cead8f5357891f5fbd2ce1b829f2fd238d674b2b/src/whisper.cpp#L3367-L3376

https://github.com/ggml-org/whisper.cpp/blob/cead8f5357891f5fbd2ce1b829f2fd238d674b2b/src/whisper.cpp#L3378-L3388