### PR TITLE
ci : add support for tag-based releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -62,8 +64,11 @@ jobs:
           echo "BRANCH_NAME: ${{ env.BRANCH_NAME }}"
           echo "CUSTOM_TAG: $CUSTOM_TAG"
 
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "Using pushed tag name"
+            TAG_NAME="${{ github.ref_name }}"
           # Use custom tag if provided
-          if [[ -n "$CUSTOM_TAG" ]]; then
+          elif [[ -n "$CUSTOM_TAG" ]]; then
             echo "Using custom tag"
             TAG_NAME="${CUSTOM_TAG}"
           elif [[ "${{ env.BRANCH_NAME }}" == "master" ]]; then
@@ -1226,7 +1231,8 @@ jobs:
           ./build/bin/quantize models/ggml-tiny.en.bin models/ggml-tiny.en-q4_0.bin q4_0
 
   release:
-    if: ${{ github.event.inputs.create_release == 'true' || github.event.inputs.pre_release_tag != '' }}
+    if: ${{ github.event.inputs.create_release == 'true' || github.event.inputs.pre_release_tag != '' || startsWith(github.ref, 'refs/tags/v') }}
+
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow to support tag-based releases. When a tag is pushed that starts with 'v', the workflow will use that tag name for the release process.

I think this was the once the behavior, but it was lost in updates that I've made to the workflow. This commit restores that functionality.

----
I've tested this on my fork by performing the following:
```console
$ git tag -d v1.7.6
$ git push origin --delete v1.7.6
# commited the commit in this PR so that it gets included in the tag
$ git tag v1.7.6
$ git push origin v1.7.6
```
The produced the following [release](https://github.com/danbev/whisper.cpp/releases/tag/v1.7.6). 

Sorry about this, but I think we might have to do something similar on master to get the release artifacts published.