### PR TITLE
whisper : add version function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,10 @@ get_directory_property(WHISPER_TRANSIENT_DEFINES COMPILE_DEFINITIONS)
 set_target_properties(whisper PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/whisper.h)
 install(TARGETS whisper LIBRARY PUBLIC_HEADER)
 
+target_compile_definitions(whisper PRIVATE
+    WHISPER_VERSION="${PROJECT_VERSION}"
+)
+
 configure_package_config_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/whisper-config.cmake.in
         ${CMAKE_CURRENT_BINARY_DIR}/whisper-config.cmake

--- a/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
@@ -5,6 +5,17 @@ project(whisper.cpp)
 set(CMAKE_CXX_STANDARD 17)
 set(WHISPER_LIB_DIR ${CMAKE_SOURCE_DIR}/../../../../../../../)
 
+# Get whisper.cpp version
+file(READ "${WHISPER_LIB_DIR}/CMakeLists.txt" MAIN_CMAKE_CONTENT)
+string(REGEX MATCH "project\\(\"whisper\\.cpp\" VERSION ([0-9]+\\.[0-9]+\\.[0-9]+)\\)" VERSION_MATCH "${MAIN_CMAKE_CONTENT}")
+if(CMAKE_MATCH_1)
+    set(WHISPER_VERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
+else()
+    set(WHISPER_VERSION "unknown" PARENT_SCOPE)
+endif()
+
+message(STATUS " Whisper version: ${WHISPER_VERSION}")
+
 set(SOURCE_FILES
     ${WHISPER_LIB_DIR}/src/whisper.cpp
     ${CMAKE_SOURCE_DIR}/jni.c
@@ -26,6 +37,7 @@ function(build_library target_name)
 
     target_link_libraries(${target_name} ${LOG_LIB} android ggml)
     target_compile_definitions(${target_name} PUBLIC GGML_USE_CPU)
+    target_compile_definitions(${target_name} PRIVATE WHISPER_VERSION="${WHISPER_VERSION}")
 
     if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)

--- a/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
@@ -5,6 +5,17 @@ project(whisper.cpp)
 set(CMAKE_CXX_STANDARD 17)
 set(WHISPER_LIB_DIR ${CMAKE_SOURCE_DIR}/../../../../../../..)
 
+# Get whisper.cpp version
+file(READ "${WHISPER_LIB_DIR}/CMakeLists.txt" MAIN_CMAKE_CONTENT)
+string(REGEX MATCH "project\\(\"whisper\\.cpp\" VERSION ([0-9]+\\.[0-9]+\\.[0-9]+)\\)" VERSION_MATCH "${MAIN_CMAKE_CONTENT}")
+if(CMAKE_MATCH_1)
+    set(WHISPER_VERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
+else()
+    set(WHISPER_VERSION "unknown" PARENT_SCOPE)
+endif()
+
+message(STATUS " Whisper version: ${WHISPER_VERSION}")
+
 # Path to external GGML, otherwise uses the copy in whisper.cpp.
 option(GGML_HOME "whisper: Path to external GGML source" OFF)
 
@@ -26,6 +37,7 @@ function(build_library target_name)
     )
 
     target_compile_definitions(${target_name} PUBLIC GGML_USE_CPU)
+    target_compile_definitions(${target_name} PRIVATE WHISPER_VERSION="${WHISPER_VERSION}")
 
     if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -198,6 +198,8 @@ extern "C" {
         float samples_overlap;         // Overlap in seconds when copying audio samples from speech segment.
     } whisper_vad_params;
 
+    WHISPER_API const char * whisper_version(void);
+
     // Various functions for loading a ggml whisper model.
     // Allocate (almost) all memory needed for the model.
     // Return NULL on failure

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -8938,6 +8938,10 @@ void whisper_log_set(ggml_log_callback log_callback, void * user_data) {
     ggml_log_set(g_state.log_callback, g_state.log_callback_user_data);
 }
 
+const char * whisper_version(void) {
+    return WHISPER_VERSION;
+}
+
 GGML_ATTRIBUTE_FORMAT(2, 3)
 static void whisper_log_internal(ggml_log_level level, const char * format, ...) {
     va_list args;


### PR DESCRIPTION
This commit adds a version function to the whisper API.

The motivation for this is that it might be convenient to have a way to programmatically check the version.

Example usage:
```c++
printf("Using whisper version: %s\n", whisper_version());
```
Will output:
```console
Using whisper version: 1.7.6
```