### PR TITLE
ci: set fail-fast to false in docker.yml

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       COMMIT_SHA: ${{ github.sha }}
     strategy:
+      fail-fast: false
       matrix:
         config:
           - { tag: "main", dockerfile: ".devops/main.Dockerfile", platform: "linux/amd64" }

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,21 +42,20 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image (versioned)
-        if: github.event_name == 'push'
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          push: true
-          platforms: ${{ matrix.config.platform }}
-          tags: "ghcr.io/${{ github.repository }}:${{ matrix.config.tag }}-${{ env.COMMIT_SHA }}"
-          file: ${{ matrix.config.dockerfile }}
+      - name: Generate tags
+        id: tags
+        run: |
+          TAGS="ghcr.io/${{ github.repository }}:${{ matrix.config.tag }}"
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TAGS="$TAGS,ghcr.io/${{ github.repository }}:${{ matrix.config.tag }}-${{ env.COMMIT_SHA }}"
+          fi
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image (tagged)
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
           push: ${{ github.event_name == 'push' }}
           platforms: ${{ matrix.config.platform }}
-          tags: "ghcr.io/${{ github.repository }}:${{ matrix.config.tag }}"
+          tags: ${{ steps.tags.outputs.tags }}
           file: ${{ matrix.config.dockerfile }}


### PR DESCRIPTION
This commit modifies the GitHub Actions workflow for Docker builds to disable the fail-fast behavior.

The motivation for this is that currently if one of the strategy jobs fails any other job that is in progress will be cancelled. There is no need for this as the jobs are independent.