### PR TITLE
ci : use selective copy for musa image

### DIFF
--- a/.devops/main-musa.Dockerfile
+++ b/.devops/main-musa.Dockerfile
@@ -32,8 +32,9 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/* /tmp/* /var/tmp/*
 
-COPY --from=build /app /app
-RUN du -sh /app/*
-RUN find /app -type f -size +100M
+COPY --from=build /app/build/bin /app/build/bin
+COPY --from=build /app/samples /app/samples
+COPY --from=build /app/models /app/models
+
 ENV PATH=/app/build/bin:$PATH
 ENTRYPOINT [ "bash", "-c" ]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,6 +42,21 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Free up disk space
+        run: |
+          sudo apt-get remove -y '^dotnet-.*' '^llvm-.*' '^mysql-.*' '^postgresql-.*'
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean
+
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
+          docker system prune -af
+
+          df -h
+
       - name: Generate tags
         id: tags
         run: |


### PR DESCRIPTION
This commit modified the musa docker file to selectively copy directories needed for the container image.
This commit also added a step to the docker workflow to free up disk space in attempt to make enough room for the large musa build containers.

The motivation for this change is to reduce the size of the container image and try to avoid disk usage issues in CI.