### PR TITLE
[BUGFIX] sycl: Fix macro collision with standard math functions

### DIFF
--- a/ggml/src/ggml-sycl/common.hpp
+++ b/ggml/src/ggml-sycl/common.hpp
@@ -13,6 +13,19 @@
 #ifndef GGML_SYCL_COMMON_HPP
 #define GGML_SYCL_COMMON_HPP
 
+// ─── Fix: Undefine math macros before SYCL includes ───────────────────
+#undef isnan
+#undef isinf
+#undef isfinite
+#undef signbit
+#undef isgreater
+#undef isgreaterequal
+#undef isless
+#undef islessequal
+#undef islessgreater
+#undef isunordered
+// ──────────────────────────────────────────────────────────────────────
+
 #include <cstddef>
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
Hi there!

I found a fix for the compile time bugs/errors I've been getting here:

https://github.com/ggml-org/whisper.cpp/issues/3297

I'm by no means a C++ expert & I'm sure there is a more elegant way to fix this.


This fixed the compilation for me, now I can run whisper models with SYCL hardware accelaration on my
Intel Ultra Series 2 laptop Omnibook Ultra Flip 14" !!!

CPU: Intel Ultra 7 258V (8) @ 4.800GHz
GPU: Intel Arc Graphics 130V / 140V]
 