### PR TITLE
Adding dtw.params to server.cpp for v3-large-turbo

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -674,7 +674,9 @@ int main(int argc, char ** argv) {
         if (params.dtw == "large.v3") {
             cparams.dtw_aheads_preset = WHISPER_AHEADS_LARGE_V3;
         }
-
+        if (params.dtw == "large.v3.turbo") { 
+            cparams.dtw_aheads_preset = WHISPER_AHEADS_LARGE_V3_TURBO;
+        }
         if (cparams.dtw_aheads_preset == WHISPER_AHEADS_NONE) {
             fprintf(stderr, "error: unknown DTW preset '%s'\n", params.dtw.c_str());
             return 3;

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -677,6 +677,7 @@ int main(int argc, char ** argv) {
         if (params.dtw == "large.v3.turbo") { 
             cparams.dtw_aheads_preset = WHISPER_AHEADS_LARGE_V3_TURBO;
         }
+        
         if (cparams.dtw_aheads_preset == WHISPER_AHEADS_NONE) {
             fprintf(stderr, "error: unknown DTW preset '%s'\n", params.dtw.c_str());
             return 3;


### PR DESCRIPTION
Hi. I noticed that the dtw option had the v3-large-turbo model support added in #2481 but this wasn't added into the example server.cpp

This pull request should remedy that - I used the same style as in main.cpp (calling it v3.large.turbo and matched the original line spacing before the "none" option.)

I've tested building it using my own dockerfile (I build whispercpp with openvino support) and it appears to work as expected.

Please note: I'm new at github and contributing to OSS software in general, so my apologies if I've done something wrong.

If I can change something or make it better, please let me know - I'm trying to learn.

Thank you.