### PR TITLE
If backends fail it is possible to try using a null pointer

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1,4 +1,4 @@
-`#include "whisper.h"
+#include "whisper.h"
 #include "whisper-arch.h"
 
 #include "ggml.h"


### PR DESCRIPTION
This is, hopefully, slighly cleaner than a core dump