### PR TITLE
Whisper-stream: Add `--pausable` / `-p` — live **Pause / Resume** control

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -276,8 +276,8 @@ int main(int argc, char ** argv) {
         if (params.pausable) {
             int st = control_state.exchange(0);
             if (st == 1 && !is_paused) {
-                audio.pause();
                 audio.clear();
+                audio.pause();
 
                 params.no_context = true;
 
@@ -288,8 +288,8 @@ int main(int argc, char ** argv) {
                 is_paused = true;
                 whisper_reset_timings(ctx);
             } else if (st == 2 && is_paused) {
-                audio.clear();
                 audio.resume();
+                audio.clear();
                 whisper_reset_timings(ctx);
                 is_paused = false;
                 t_last = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
## ✨ Add `--pausable` / `-p` — live **Pause / Resume** control

### Overview
Enabling `--pausable` lets you **temporarily suspend** and **resume** real-time transcription without restarting the program.

| Action | Stdin command |
|--------|---------------|
| Pause  | `p` **followed by a newline** (`p\n`) |
| Resume | `r` **followed by a newline** (`r\n`) |

> The control thread reads from **stdin**.  
> Most terminals add `\n` automatically when you press **Enter**, so type `p⏎` or `r⏎`.

---

### Why it matters
* Pause long sessions to save CPU/GPU and keep the transcript clean.  
* Prevent residual words from the previous utterance from leaking into the next one.  
* Convenient when Whisper is part of an interactive pipeline that needs on-demand control.

---

### Implementation details
* **CLI** — new flag `--pausable` (`-p`), default **off** (backward-compatible).  
* **Control thread** — listens on `stdin` for `p\n` / `r\n`; unknown commands print a warning and are ignored.  
* **Pause workflow**
  ```cpp
  audio.pause();            // stop capture
  audio.clear();            // flush ring buffer

  pcmf32.clear();
  pcmf32_new.clear();
  pcmf32_old.clear();
  prompt_tokens.clear();

  whisper_reset_timings(ctx);
  t_last = std::chrono::high_resolution_clock::now();
  is_paused = true;
