### PR TITLE
ci : add paths to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,25 @@ on:
       - master
     tags:
       - 'v*'
+    paths: ['.github/workflows/build.yml',
+            '**/CMakeLists.txt',
+            '**/Makefile',
+            '**/*.mk',
+            '**/*.cmake',
+            '**/*.in',
+            '**/*.h',
+            '**/*.hpp',
+            '**/*.c',
+            '**/*.cpp',
+            '**/*.cu',
+            '**/*.cuh',
+            '**/*.cl',
+            '**/*.swift',
+            '**/*.m',
+            '**/*.mm',
+            '**/*.metal',
+            '**/*.comp',
+            '**/*.java']
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:


### PR DESCRIPTION
This commit adds specific paths to the GitHub Actions workflow file `.github/workflows/build.yml`.

The motivation for this to avoid unnecessary builds when unrelated files are changed, which can save resources and time during the CI process.

Refs: https://github.com/ggml-org/whisper.cpp/issues/3285