### PR TITLE
node : add win platform check for require path

### DIFF
--- a/examples/addon.node/index.js
+++ b/examples/addon.node/index.js
@@ -1,8 +1,10 @@
-const path = require("path");
-const { whisper } = require(path.join(
-  __dirname,
-  "../../build/Release/addon.node"
-));
+const path = require('path');
+const os = require('os');
+
+const isWindows = os.platform() === 'win32';
+const buildPath = isWindows ? "../../build/bin/Release/addon.node" : "../../build/Release/addon.node";
+
+const { whisper } = require(path.join(__dirname, buildPath));
 const { promisify } = require("util");
 
 const whisperAsync = promisify(whisper);


### PR DESCRIPTION
This commit adds a check to the platform in use and adjust the path to the addon.node shared library.

The motivation for this change is that on windows addon.node library is built into build\bin\Release and on linux into build/Release.

Resolves: https://github.com/ggml-org/whisper.cpp/issues/3360

----
With this change I'm able to run the example using the following command:
```console
> node index.js --language='en' --model='../../models/ggml-base.en.bin' --fname_inp='../../samples/jfk.wav'
whisperParams = {
  language: 'en',
  model: '../../models/ggml-base.en.bin',
  fname_inp: '../../samples/jfk.wav',
  use_gpu: true,
  flash_attn: false,
  no_prints: true,
  comma_in_time: false,
  translate: true,
  no_timestamps: false,
  detect_language: false,
  audio_ctx: 0,
  max_len: 0,
  progress_callback: [Function: progress_callback]
}
progress: 0%

progress: 100%

{
  transcription: [
    [
      '00:00:00.000',
      '00:00:11.000',
      ' And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.'
    ]
  ]
}
```