### PR TITLE
whisper : fixed crash in GPU device selection on multi-GPU systems

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1327,7 +1327,7 @@ static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & pa
         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
             ggml_backend_dev_t dev_cur = ggml_backend_dev_get(i);
             if (ggml_backend_dev_type(dev_cur) == GGML_BACKEND_DEVICE_TYPE_GPU) {
-                if (cnt == 0 || cnt == params.gpu_device) {
+                if (cnt == params.gpu_device) {
                     dev = dev_cur;
                 }
 
@@ -1396,7 +1396,7 @@ static buft_list_t make_buft_list(whisper_context_params & params) {
         for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
             ggml_backend_dev_t dev = ggml_backend_dev_get(i);
             if (ggml_backend_dev_type(dev) == GGML_BACKEND_DEVICE_TYPE_GPU) {
-                if (cnt == 0 || cnt == params.gpu_device) {
+                if (cnt == params.gpu_device) {
                     auto * buft = ggml_backend_dev_buffer_type(dev);
                     if (buft) {
                         buft_list.emplace_back(dev, buft);


### PR DESCRIPTION
Note that ffmpeg has recently integrated whisper https://github.com/FFmpeg/FFmpeg/commit/13ce36fef98a3f4e6d8360c24d6b8434cbb8869b; testing on a multi-card machine with a non-zero card will cause a crash

>  ./ffmpeg -i ../test.wav -vn -af "whisper=model=../whisper.cpp/models/ggml-large-v3-turbo.bin\
:language=zh\
:gpu_device=1
:queue=3\
:destination=output.srt\
:format=srt" -f null -
ffmpeg version N-120674-g5733e08c97 Copyright (c) 2000-2025 the FFmpeg developers
  built with gcc 11 (Ubuntu 11.4.0-1ubuntu1~22.04)
  configuration: --disable-x86asm --enable-whisper
  libavutil      60.  9.100 / 60.  9.100
  libavcodec     62. 12.100 / 62. 12.100
  libavformat    62.  4.100 / 62.  4.100
  libavdevice    62.  2.100 / 62.  2.100
  libavfilter    11.  5.100 / 11.  5.100
  libswscale      9.  2.100 /  9.  2.100
  libswresample   6.  2.100 /  6.  2.100
[aist#0:0/pcm_s16le @ 0x5568ff8dabc0] Guessed Channel Layout: mono
Input #0, wav, from '../test.wav':
  Metadata:
    encoder         : Lavf58.76.100
  Duration: 00:00:58.62, bitrate: 256 kb/s
  Stream #0:0: Audio: pcm_s16le ([1][0][0][0] / 0x0001), 16000 Hz, mono, s16, 256 kb/s
[Parsed_whisper_0 @ 0x5568ff8be280] whisper gpu  1   gpu-id:1
/home/zhibo/dw/whisper.cpp/ggml/src/ggml-backend.cpp:736: pre-allocated tensor (leaf_0) in a buffer (CUDA0) that cannot run the operation (NONE)
/usr/local/lib/libggml-base.so(+0x16ceb)[0x7fd221397ceb]
/usr/local/lib/libggml-base.so(ggml_print_backtrace+0x21f)[0x7fd22139814f]
/usr/local/lib/libggml-base.so(ggml_abort+0x152)[0x7fd221398322]
/usr/local/lib/libggml-base.so(+0x2c174)[0x7fd2213ad174]
/usr/local/lib/libggml-base.so(+0x2d846)[0x7fd2213ae846]
/usr/local/lib/libggml-base.so(ggml_backend_sched_alloc_graph+0xcd)[0x7fd2213b007d]
/usr/local/lib/libwhisper.so.1(+0x30163)[0x7fd232886163]
/usr/local/lib/libwhisper.so.1(whisper_init_state+0x99a)[0x7fd23288b1da]
/usr/local/lib/libwhisper.so.1(whisper_init_from_file_with_params+0x37)[0x7fd2328953d7]
./ffmpeg(+0x41cf6a)[0x5568d4beef6a]
./ffmpeg(+0x1f9dcf)[0x5568d49cbdcf]
./ffmpeg(+0x20f928)[0x5568d49e1928]
./ffmpeg(+0x21025b)[0x5568d49e225b]
./ffmpeg(+0x1a5e11)[0x5568d4977e11]
./ffmpeg(+0x1a95bf)[0x5568d497b5bf]
./ffmpeg(+0x1ab6f3)[0x5568d497d6f3]
./ffmpeg(+0x1b11f0)[0x5568d49831f0]
./ffmpeg(+0x1b2b9f)[0x5568d4984b9f]
./ffmpeg(+0x1b30e9)[0x5568d49850e9]
./ffmpeg(+0x1b3b39)[0x5568d4985b39]
./ffmpeg(+0x1b7a97)[0x5568d4989a97]
./ffmpeg(+0x1baecb)[0x5568d498cecb]
./ffmpeg(+0x199a48)[0x5568d496ba48]
/lib/x86_64-linux-gnu/libc.so.6(+0x29d90)[0x7fd232656d90]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80)[0x7fd232656e40]
./ffmpeg(+0x19a565)[0x5568d496c565]