### PR TITLE
Fix ReDoS in chessboard FEN sanitize (/ .+$/) used by examples/wchess

### DIFF
--- a/examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js
+++ b/examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js
@@ -227,7 +227,7 @@
 
     // cut off any move, castling, etc info from the end
     // we're only interested in position information
-    fen = fen.replace(/ .+$/, '')
+    fen = fen.replace(/ (?! ).+$/, '')
 
     // expand the empty square numbers to just 1s
     fen = expandFenEmptySquares(fen)
@@ -1815,3 +1815,4 @@
   window['Chessboard']['fenToObj'] = fenToObj
   window['Chessboard']['objToFen'] = objToFen
 })() // end anonymous wrapper
+

--- a/js-tests/fen-redos.spec.js
+++ b/js-tests/fen-redos.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env mocha */
+const { expect } = require('chai');
+const { performance } = require('perf_hooks');
+const path = require('path');
+
+// —— 最小浏览器 & jQuery stub，避免 DOM 依赖 ——
+global.window = global;
+global.document = {};
+global.jQuery = function(){};
+global.$ = global.jQuery;
+
+
+const target = path.join(
+  __dirname,
+  '..',
+  'examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js'
+);
+
+// 载入真实实现（会把 Chessboard 挂到全局）
+require(target);
+const Chessboard = global.Chessboard;
+
+describe('FEN sanitize ReDoS in whisper.cpp (fen = fen.replace(/ .+$/, \'\'))', function () {
+  this.timeout(60_000);
+
+  it('should complete within 2 seconds', function () {
+    const N = 100000; 
+    const attack = ' '.repeat(N) + '\n@';
+
+    const t0 = performance.now();
+    try { Chessboard.fenToObj(attack); } catch (_) {}
+    const ms = performance.now() - t0;
+
+
+    expect(ms).to.be.lessThan(2_000);
+  });
+});
+
+
+
+

--- a/js-tests/package.json
+++ b/js-tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "whispercpp-js-tests",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "mocha \"*.spec.js\""
+  },
+  "devDependencies": {
+    "mocha": "^10.6.0",
+    "chai": "^4.4.1"
+  }
+}


### PR DESCRIPTION
### What does this PR do?

Reports and fixes a potential **Regular Expression Denial of Service (ReDoS)** in the FEN–sanitize step of the embedded chessboard script. With a crafted input the regex can cause extremely high CPU usage and freeze the process.

**File:**
`examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js`

**Before**

```js
fen = fen.replace(/ .+$/, '');
```

**After (fix)**

```js
// eliminate catastrophic backtracking by removing the overlap after the space
fen = fen.replace(/ (?! ).+$/, '');
```

---

### Why is this needed?

The pattern `/ .+$/` is vulnerable to catastrophic backtracking.
When the input looks like:

```
" ".repeat(N) + "\n@"
```

`.` does not cross the newline, while `$` forces a match at end-of-string; the leading space overlaps with the first set of `.+`, so the engine backtracks quadratically from each starting space. This leads to long stalls (tens of seconds on common hardware).

The new pattern adds a **negative lookahead** `(?! )` to ensure the `.+` part does not start with another space, removing the overlap and making the match **linear-time**. For valid FEN (which uses a single space after the position), behavior is unchanged. Inputs with multiple consecutive spaces are intentionally not trimmed (safer semantics).

> Alternative safe forms (if preferred) with equivalent performance:
>
> ```js
> // forbid crossing newlines without lookahead ($ no longer needed)
> fen = fen.replace(/ [^\n]*$/, '');
> // or avoid regex entirely:
> const i = fen.indexOf(' '); fen = i === -1 ? fen : fen.slice(0, i);
> ```

---

### How I reproduced and verified
before：
<img width="822" height="515" alt="image" src="https://github.com/user-attachments/assets/3199d19d-af4f-4734-9411-a62f51b61be1" />


after：
<img width="887" height="230" alt="屏幕截图 2025-08-13 165059" src="https://github.com/user-attachments/assets/c9ec0a73-f883-4ecf-8b6f-38a847b65c40" />

step：
git clone https://github.com/wukunyu264/whisper.cpp.git
cd  whisper.cpp
npm i --prefix js-tests
cd js-tests
npm test
---

### Type of change

* **Bugfix**



### Backwards compatibility

* No breaking change for **valid FEN** strings (single space separator).
* Stricter behavior for malformed inputs with consecutive spaces (they are no longer trimmed), which is safer.



### Security / performance impact

* Removes a ReDoS vector in the example’s JavaScript path.
* Changes worst-case complexity from super-linear backtracking to **O(n)**.

