### PR TITLE
Update `./models/download-ggml-model.cmd` to allow for tdrz download

### DIFF
--- a/models/download-ggml-model.cmd
+++ b/models/download-ggml-model.cmd
@@ -78,7 +78,8 @@ echo %model% | findstr tdrz
 if %ERRORLEVEL% neq 0 (
  PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-%model%.bin -Destination \"%models_path%\\ggml-%model%.bin\""
 ) else (
-  PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source https://huggingface.co/akashmjn/tinydiarize-whisper.cpp/resolve/main/ggml-%model%.bin -Destination \"%models_path%\\ggml-%model%.bin\"
+  PowerShell -NoProfile -ExecutionPolicy Bypass -Command "Start-BitsTransfer -Source https://huggingface.co/akashmjn/tinydiarize-whisper.cpp/resolve/main/ggml-%model%.bin -Destination \"%models_path%\\ggml-%model%.bin\""
+
 )
 
 if %ERRORLEVEL% neq 0 (


### PR DESCRIPTION
Added a couple of lines to validate whether `tdrz` is in the argument much like the shell version of this script. Uses findstr (built into cmd.exe) as the grep alternative and `%ERRORLEVEL%` to validate as in the next step., which resolves error checking correctly as well.

I think this introduces an echo of the downloaded model's name in the output, but that's a single line & negligible.