### PR TITLE
Ruby binding: handle negative value in padding

### DIFF
--- a/bindings/ruby/lib/whisper/model/uri.rb
+++ b/bindings/ruby/lib/whisper/model/uri.rb
@@ -94,7 +94,7 @@ module Whisper
       end
 
       def show_progress(current, size)
-        progress_rate_available = size && $stderr.tty?
+        progress_rate_available = size && $stderr.tty? && $stderr.winsize[1] >= line.size
 
         unless @prev
           @prev = Time.now


### PR DESCRIPTION
this might happen depending on the way the $stderr.winsize is defined.
If the expression "$stderr.winsize[1] - line.size" in Line 114 gets negative, we will get a "negative argument" exception in the padding calculation