### PR TITLE
ci : remove brew installation of cmake for macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -241,7 +241,8 @@ jobs:
       - name: Dependencies
         run: |
           brew update
-          brew install sdl2 cmake
+          cmake --version
+          brew install sdl2
 
       - name: Build
         run: |


### PR DESCRIPTION
This commit remove the brew install of cmake for macos-latest as this now seems to be pre-installed on the runner.

The motivation for this is that this job is failing with the following error:
```console
Error: cmake was installed from the local/pinned tap
but you are trying to install it from the homebrew/core tap.
Formulae with the same name from different taps cannot be installed at the same time.
```