### PR TITLE
common : only allow filename as read_audio_data argument

### DIFF
--- a/examples/common-whisper.cpp
+++ b/examples/common-whisper.cpp
@@ -74,6 +74,8 @@ bool read_audio_data(const std::string & fname, std::vector<float>& pcmf32, std:
     }
     else if (((result = ma_decoder_init_file(fname.c_str(), &decoder_config, &decoder)) != MA_SUCCESS)) {
 #if defined(WHISPER_FFMPEG)
+        fprintf(stderr, "warning: failed to read audio data from file: %s\n", ma_result_description(result));
+
 		if (ffmpeg_decode_audio(fname, audio_data) != 0) {
 			fprintf(stderr, "error: failed to ffmpeg decode '%s'\n", fname.c_str());
 
@@ -86,11 +88,9 @@ bool read_audio_data(const std::string & fname, std::vector<float>& pcmf32, std:
 			return false;
 		}
 #else
-		if ((result = ma_decoder_init_memory(fname.c_str(), fname.size(), &decoder_config, &decoder)) != MA_SUCCESS) {
-			fprintf(stderr, "error: failed to read audio data as wav (%s)\n", ma_result_description(result));
+        fprintf(stderr, "error: failed to read audio data from file (%s)\n", ma_result_description(result));
 
-			return false;
-		}
+        return false;
 #endif
     }
 

--- a/examples/common-whisper.h
+++ b/examples/common-whisper.h
@@ -5,7 +5,6 @@
 #include <cstdint>
 
 // Read WAV audio file and store the PCM data into pcmf32
-// fname can be a buffer of WAV data instead of a filename
 // The sample rate of the audio must be equal to COMMON_SAMPLE_RATE
 // If stereo flag is set and the audio has 2 channels, the pcmf32s will contain 2 channel PCM
 bool read_audio_data(


### PR DESCRIPTION
The read_audio_data API was confusingly designed to accept either a filename or raw audio buffer.

The server example was the only one passing audio_file.content (raw buffer) directly, which worked until WHISPER_FFMPEG=yes where ffmpeg_decode_audio would try to treat the raw audio buffer as a filename after ma_decoder_init_file failed. Now we always write to a temp file first, making the API cleaner and more consistent.