### PR TITLE
go bindings: allow use of the use_gpu and flash_attn options

### DIFF
--- a/bindings/go/context_params.go
+++ b/bindings/go/context_params.go
@@ -1,0 +1,24 @@
+package whisper
+
+type (
+	contextParamsOption     interface{ apply(*ContextParams) }
+	contextParamsOptionFunc func(*ContextParams)
+)
+
+func (fn contextParamsOptionFunc) apply(to *ContextParams) {
+	fn(to)
+}
+
+func WithUseGPU(v bool) contextParamsOption {
+	return contextParamsOptionFunc(func(p *ContextParams) {
+		p.SetUseGPU(v)
+	})
+}
+
+func (p *ContextParams) UseGPU() bool {
+	return bool(p.use_gpu)
+}
+
+func (p *ContextParams) SetUseGPU(v bool) {
+	p.use_gpu = toBool(v)
+}

--- a/bindings/go/context_params.go
+++ b/bindings/go/context_params.go
@@ -1,24 +1,17 @@
 package whisper
 
-type (
-	contextParamsOption     interface{ apply(*ContextParams) }
-	contextParamsOptionFunc func(*ContextParams)
-)
-
-func (fn contextParamsOptionFunc) apply(to *ContextParams) {
-	fn(to)
-}
-
-func WithUseGPU(v bool) contextParamsOption {
-	return contextParamsOptionFunc(func(p *ContextParams) {
-		p.SetUseGPU(v)
-	})
-}
-
 func (p *ContextParams) UseGPU() bool {
 	return bool(p.use_gpu)
 }
 
 func (p *ContextParams) SetUseGPU(v bool) {
 	p.use_gpu = toBool(v)
+}
+
+func (p *ContextParams) UseFlashAttention() bool {
+	return bool(p.flash_attn)
+}
+
+func (p *ContextParams) SetUseFlashAttention(v bool) {
+	p.flash_attn = toBool(v)
 }

--- a/bindings/go/pkg/whisper/model_option.go
+++ b/bindings/go/pkg/whisper/model_option.go
@@ -1,0 +1,26 @@
+package whisper
+
+import whisper "github.com/ggerganov/whisper.cpp/bindings/go"
+
+type ContextParams = whisper.ContextParams
+
+type (
+	modelOption     interface{ apply(*ContextParams) }
+	modelOptionFunc func(*ContextParams)
+)
+
+func (fn modelOptionFunc) apply(to *ContextParams) {
+	fn(to)
+}
+
+func WithUseGPU(v bool) modelOption {
+	return modelOptionFunc(func(p *ContextParams) {
+		p.SetUseGPU(v)
+	})
+}
+
+func WithUseFlashAttention(v bool) modelOption {
+	return modelOptionFunc(func(p *ContextParams) {
+		p.SetUseFlashAttention(v)
+	})
+}

--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -102,18 +102,22 @@ var (
 
 // Allocates all memory needed for the model and loads the model from the given file.
 // Returns NULL on failure.
-func Whisper_init(path string, options ...contextParamsOption) *Context {
+func Whisper_init(path string) *Context {
+	return Whisper_init_with_params(path, DefaultContextParams())
+}
+
+func Whisper_init_with_params(path string, params ContextParams) *Context {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
-	params := ContextParams(C.whisper_context_default_params())
-	for _, o := range options {
-		o.apply(&params)
-	}
 	if ctx := C.whisper_init_from_file_with_params(cPath, (C.struct_whisper_context_params)(params)); ctx != nil {
 		return (*Context)(ctx)
 	} else {
 		return nil
 	}
+}
+
+func DefaultContextParams() ContextParams {
+	return ContextParams(C.whisper_context_default_params())
 }
 
 // Frees all memory allocated by the model.

--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -71,6 +71,7 @@ type (
 	TokenData        C.struct_whisper_token_data
 	SamplingStrategy C.enum_whisper_sampling_strategy
 	Params           C.struct_whisper_full_params
+	ContextParams    C.struct_whisper_context_params
 )
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -101,10 +102,14 @@ var (
 
 // Allocates all memory needed for the model and loads the model from the given file.
 // Returns NULL on failure.
-func Whisper_init(path string) *Context {
+func Whisper_init(path string, options ...contextParamsOption) *Context {
 	cPath := C.CString(path)
 	defer C.free(unsafe.Pointer(cPath))
-	if ctx := C.whisper_init_from_file_with_params(cPath, C.whisper_context_default_params()); ctx != nil {
+	params := ContextParams(C.whisper_context_default_params())
+	for _, o := range options {
+		o.apply(&params)
+	}
+	if ctx := C.whisper_init_from_file_with_params(cPath, (C.struct_whisper_context_params)(params)); ctx != nil {
 		return (*Context)(ctx)
 	} else {
 		return nil


### PR DESCRIPTION
This pr allows use of the model options in Go bindings: use_gpu and flash_attn.

So if you are lucky man and you work on macOS (Intel) then you could write following:
```go
	model, err := whisper.New("../../models/ggml-base.bin", whisper.WithUseGPU(false))
	if err != nil {
		slog.Error("error initializing a whisper model", "error", err)
		return
	}
```