### PR TITLE
Fixed VAD to work when using whisper_full_with_state

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6802,23 +6802,12 @@ static bool whisper_vad(
 }
 
 int whisper_full_with_state(
-        struct whisper_context * ctx,
-          struct whisper_state * state,
-    struct whisper_full_params   params,
-                   const float * samples,
-                           int   n_samples) {
-    // clear old results
-    auto & result_all = state->result_all;
-
-    result_all.clear();
-
-    if (n_samples > 0) {
-        // compute log mel spectrogram
-        if (whisper_pcm_to_mel_with_state(ctx, state, samples, n_samples, params.n_threads) != 0) {
-            WHISPER_LOG_ERROR("%s: failed to compute log mel spectrogram\n", __func__);
-            return -2;
-        }
-    }
+    struct whisper_context *ctx,
+    struct whisper_state *state,
+    struct whisper_full_params params,
+    const float *samples,
+    int n_samples)
+{
 
     std::vector<float> vad_samples;
     if (params.vad)
@@ -6836,6 +6825,21 @@ int whisper_full_with_state(
         }
         samples = vad_samples.data();
         n_samples = vad_samples.size();
+    }
+
+    // clear old results
+    auto &result_all = state->result_all;
+
+    result_all.clear();
+
+    if (n_samples > 0)
+    {
+        // compute log mel spectrogram
+        if (whisper_pcm_to_mel_with_state(ctx, state, samples, n_samples, params.n_threads) != 0)
+        {
+            WHISPER_LOG_ERROR("%s: failed to compute log mel spectrogram\n", __func__);
+            return -2;
+        }
     }
 
     // auto-detect language if not specified


### PR DESCRIPTION
Currently `whisper_full_with_state` doesn't work with VAD.

The main inference method is `whisper_full_with_state`. This method takes a `whisper_context` and a `whisper_state`. On top of this method are built 2 convenience methods, `whisper_full` and `whisper_full_parallel`.

The VAD logic is currently only implemented in those convenience methods, but not in `whisper_full_with_state` itself. This is an issue whenever we need to deal with more than one state (when processing multiple real time streams for example).

This pull request moves the logic into `whisper_full_with_state` and fix a few incorrect calls to `ctx->state` instead of `state` directly.