### PR TITLE
bindings-ruby : enable setting of flash-attn

### DIFF
--- a/bindings/ruby/test/test_whisper.rb
+++ b/bindings/ruby/test/test_whisper.rb
@@ -30,7 +30,7 @@ class TestWhisper < TestBase
   end
 
   def test_transcribe_n_processors
-    @whisper = Whisper::Context.new("base.en")
+    @whisper = Whisper::Context.new("base.en", flash_attn: false)
     params  = Whisper::Params.new
 
     @whisper.transcribe(AUDIO, params, n_processors: 4) {|text|


### PR DESCRIPTION
This commit enables the flast_attn context parameter to be set in the Ruby bindings.

The motivation for this is that the default setting for this recently changed to true, which causes the following test to fail:
```console
Failure: test_transcribe_n_processors(TestWhisper):
  </ask not what your country can do for you[,.] ask what you can do for your country/i> was expected to be =~
  <" And so, my fellow Americans! Ask not what you do. what your country can do for you. Ask what you can do for your country.">.
```
An alternative could also be to change the test.