### PR TITLE
go: update module path

### DIFF
--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -12,7 +12,7 @@ is as follows:
 
 ```go
 import (
-	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	"github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 )
 
 func main() {
@@ -84,7 +84,7 @@ And you can then test a model against samples with the following command:
 
 To use the bindings in your own software,
 
-  1. Import `github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper` (or `github.com/ggerganov/whisper.cpp/bindings/go` into your package;
+  1. Import `github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper` (or `github.com/ggml-org/whisper.cpp/bindings/go` into your package;
   2. Compile `libwhisper.a` (you can use `make whisper` in the `bindings/go` directory);
   3. Link your go binary against whisper by setting the environment variables `C_INCLUDE_PATH` and `LIBRARY_PATH`
      to point to the `whisper.h` file directory and `libwhisper.a` file directory respectively.
@@ -93,8 +93,8 @@ Look at the `Makefile` in the `bindings/go` directory for an example.
 
 The API Documentation:
 
-  * https://pkg.go.dev/github.com/ggerganov/whisper.cpp/bindings/go
-  * https://pkg.go.dev/github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper
+  * https://pkg.go.dev/github.com/ggml-org/whisper.cpp/bindings/go
+  * https://pkg.go.dev/github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper
 
 Getting help:
 
@@ -103,4 +103,3 @@ Getting help:
 ## License
 
 The license for the Go bindings is the same as the license for the rest of the whisper.cpp project, which is the MIT License. See the `LICENSE` file for more details.
-

--- a/bindings/go/examples/go-whisper/flags.go
+++ b/bindings/go/examples/go-whisper/flags.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	// Packages
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 )
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/examples/go-whisper/main.go
+++ b/bindings/go/examples/go-whisper/main.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 
 	// Packages
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 )
 
 func main() {

--- a/bindings/go/examples/go-whisper/process.go
+++ b/bindings/go/examples/go-whisper/process.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	// Package imports
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 	wav "github.com/go-audio/wav"
 )
 

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/ggerganov/whisper.cpp/bindings/go
+module github.com/ggml-org/whisper.cpp/bindings/go
 
 go 1.23
 

--- a/bindings/go/pkg/whisper/consts.go
+++ b/bindings/go/pkg/whisper/consts.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	// Bindings
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go"
 )
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/pkg/whisper/context.go
+++ b/bindings/go/pkg/whisper/context.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	// Bindings
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go"
 )
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/pkg/whisper/context.go
+++ b/bindings/go/pkg/whisper/context.go
@@ -334,7 +334,7 @@ func toSegment(ctx *whisper.Context, n int) Segment {
 
 func toTokens(ctx *whisper.Context, n int) []Token {
 	result := make([]Token, ctx.Whisper_full_n_tokens(n))
-	for i := 0; i < len(result); i++ {
+	for i := range result {
 		data := ctx.Whisper_full_get_token_data(n, i)
 
 		result[i] = Token{

--- a/bindings/go/pkg/whisper/context_test.go
+++ b/bindings/go/pkg/whisper/context_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	"github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 	"github.com/go-audio/wav"
 	assert "github.com/stretchr/testify/assert"
 )

--- a/bindings/go/pkg/whisper/model.go
+++ b/bindings/go/pkg/whisper/model.go
@@ -6,7 +6,7 @@ import (
 	"runtime"
 
 	// Bindings
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go"
 )
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/pkg/whisper/model_test.go
+++ b/bindings/go/pkg/whisper/model_test.go
@@ -3,7 +3,7 @@ package whisper_test
 import (
 	"testing"
 
-	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
+	"github.com/ggml-org/whisper.cpp/bindings/go/pkg/whisper"
 	assert "github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +14,6 @@ func TestNew(t *testing.T) {
 		assert.NoError(err)
 		assert.NotNil(model)
 		defer model.Close()
-
 	})
 
 	t.Run("invalid model path", func(t *testing.T) {

--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -341,7 +341,7 @@ func (ctx *Context) Whisper_full_parallel(params Params, samples []float32, proc
 
 // Return the id of the autodetected language, returns -1 if not found
 // Added to whisper.cpp in
-// https://github.com/ggerganov/whisper.cpp/commit/a1c1583cc7cd8b75222857afc936f0638c5683d6
+// https://github.com/ggml-org/whisper.cpp/commit/a1c1583cc7cd8b75222857afc936f0638c5683d6
 //
 // Examples:
 //

--- a/bindings/go/whisper_test.go
+++ b/bindings/go/whisper_test.go
@@ -58,7 +58,7 @@ func Test_Whisper_001(t *testing.T) {
 	// Print out tokens
 	num_segments := ctx.Whisper_full_n_segments()
 	assert.GreaterOrEqual(num_segments, 1)
-	for i := 0; i < num_segments; i++ {
+	for i := range num_segments {
 		str := ctx.Whisper_full_get_segment_text(i)
 		assert.NotEmpty(str)
 		t0 := time.Duration(ctx.Whisper_full_get_segment_t0(i)) * time.Millisecond

--- a/bindings/go/whisper_test.go
+++ b/bindings/go/whisper_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	// Packages
-	whisper "github.com/ggerganov/whisper.cpp/bindings/go"
+	whisper "github.com/ggml-org/whisper.cpp/bindings/go"
 	wav "github.com/go-audio/wav"
 	assert "github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
This PR updates the module path of the Go bindings. 

This should allow to install the bindings based on published tags:

```
❯ go get github.com/ggerganov/whisper.cpp/bindings/go@v1.8.0
go: module github.com/ggerganov/whisper.cpp@v1.8.0 found, but does not contain package github.com/ggerganov/whisper.cpp/bindings/go
```

It will probably require other PR's related to the Go bindings to be updated. 