### PR TITLE
ruby : Bump Ruby bindings' version to 1.3.4

### DIFF
--- a/bindings/ruby/whispercpp.gemspec
+++ b/bindings/ruby/whispercpp.gemspec
@@ -3,7 +3,7 @@ require_relative "extsources"
 Gem::Specification.new do |s|
   s.name    = "whispercpp"
   s.authors = ["Georgi Gerganov", "Todd A. Fisher"]
-  s.version = '1.3.3'
+  s.version = '1.3.4'
   s.description = %q{High-performance inference of OpenAI's Whisper automatic speech recognition (ASR) model via Ruby}
   s.email   = 'todd.fisher@gmail.com'
   s.extra_rdoc_files = ['LICENSE', 'README.md']


### PR DESCRIPTION
There's a request: https://github.com/ggml-org/whisper.cpp/pull/3365#issuecomment-3378757225

It includes:

* CoreML support,
* parallel transcription support,
* output format support,
* `Whisper::VERSION`,
* `max_len`,
* logging fix, and
* Whisper.cpp 1.8.0

Thanks.