### PR TITLE
whisper: detect multiple languages

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6805,7 +6805,7 @@ int whisper_full_with_state(
         state->lang_id = lang_id;
         params.language = whisper_lang_str(lang_id);
 
-        WHISPER_LOG_INFO("%s: auto-detected language: %s (p = %f)\n", __func__, params.language, probs[whisper_lang_id(params.language)]);
+        WHISPER_LOG_INFO("%s: auto-detected language: %s (p = %f)\n", __func__, params.language, probs[lang_id]);
         const auto & sorted_logits_id = state->decoders[0].logits_id;
         for (const auto & prob : sorted_logits_id) {
             const auto lang_id = prob.second;


### PR DESCRIPTION
Log all language probs by descending order, when `-dl` option is used.

Related issue: https://github.com/ggml-org/whisper.cpp/issues/3018

### Example

```
% ./build/bin/whisper-cli -m ./models/ggml-tiny.bin -f ./samples/jfk.wav -dl

...

whisper_full_with_state: auto-detected language: en (p = 0.974382)
whisper_full_with_state: language prob: en (p = 0.974382)
whisper_full_with_state: language prob: la (p = 0.003810)
whisper_full_with_state: language prob: mi (p = 0.003264)
whisper_full_with_state: language prob: haw (p = 0.002682)
whisper_full_with_state: language prob: pt (p = 0.001905)
whisper_full_with_state: language prob: cy (p = 0.001250)
whisper_full_with_state: language prob: nl (p = 0.001021)
whisper_full_with_state: language prob: ru (p = 0.000987)
whisper_full_with_state: language prob: nn (p = 0.000875)
whisper_full_with_state: language prob: ms (p = 0.000811)
whisper_full_with_state: language prob: ar (p = 0.000697)
whisper_full_with_state: language prob: af (p = 0.000685)
whisper_full_with_state: language prob: ja (p = 0.000432)
whisper_full_with_state: language prob: fr (p = 0.000431)
whisper_full_with_state: language prob: de (p = 0.000428)
whisper_full_with_state: language prob: zh (p = 0.000425)
whisper_full_with_state: language prob: da (p = 0.000375)
whisper_full_with_state: language prob: ko (p = 0.000363)
whisper_full_with_state: language prob: vi (p = 0.000351)
whisper_full_with_state: language prob: hi (p = 0.000342)
whisper_full_with_state: language prob: tr (p = 0.000336)
whisper_full_with_state: language prob: uk (p = 0.000299)
whisper_full_with_state: language prob: yi (p = 0.000297)
whisper_full_with_state: language prob: ur (p = 0.000221)
whisper_full_with_state: language prob: id (p = 0.000205)
whisper_full_with_state: language prob: br (p = 0.000200)
whisper_full_with_state: language prob: bo (p = 0.000196)
whisper_full_with_state: language prob: es (p = 0.000173)
whisper_full_with_state: language prob: th (p = 0.000157)
whisper_full_with_state: language prob: sv (p = 0.000151)
whisper_full_with_state: language prob: he (p = 0.000128)
whisper_full_with_state: language prob: yo (p = 0.000126)
whisper_full_with_state: language prob: sn (p = 0.000126)
whisper_full_with_state: language prob: el (p = 0.000125)
whisper_full_with_state: language prob: fi (p = 0.000123)
whisper_full_with_state: language prob: sw (p = 0.000122)
whisper_full_with_state: language prob: ta (p = 0.000098)
whisper_full_with_state: language prob: hu (p = 0.000098)
whisper_full_with_state: language prob: ro (p = 0.000094)
whisper_full_with_state: language prob: sl (p = 0.000089)
whisper_full_with_state: language prob: km (p = 0.000074)
whisper_full_with_state: language prob: fo (p = 0.000069)
whisper_full_with_state: language prob: lt (p = 0.000066)
whisper_full_with_state: language prob: bg (p = 0.000060)
whisper_full_with_state: language prob: it (p = 0.000056)
whisper_full_with_state: language prob: jw (p = 0.000054)
whisper_full_with_state: language prob: no (p = 0.000054)
whisper_full_with_state: language prob: ht (p = 0.000043)
whisper_full_with_state: language prob: cs (p = 0.000040)
whisper_full_with_state: language prob: tl (p = 0.000040)
whisper_full_with_state: language prob: pl (p = 0.000040)
whisper_full_with_state: language prob: lv (p = 0.000039)
whisper_full_with_state: language prob: sa (p = 0.000037)
whisper_full_with_state: language prob: ml (p = 0.000036)
whisper_full_with_state: language prob: is (p = 0.000035)
whisper_full_with_state: language prob: fa (p = 0.000032)
whisper_full_with_state: language prob: sq (p = 0.000031)
whisper_full_with_state: language prob: bs (p = 0.000030)
whisper_full_with_state: language prob: bn (p = 0.000028)
whisper_full_with_state: language prob: mk (p = 0.000022)
whisper_full_with_state: language prob: hr (p = 0.000021)
whisper_full_with_state: language prob: sr (p = 0.000021)
whisper_full_with_state: language prob: my (p = 0.000017)
whisper_full_with_state: language prob: oc (p = 0.000017)
whisper_full_with_state: language prob: si (p = 0.000016)
whisper_full_with_state: language prob: gl (p = 0.000015)
whisper_full_with_state: language prob: sd (p = 0.000014)
whisper_full_with_state: language prob: az (p = 0.000014)
whisper_full_with_state: language prob: ca (p = 0.000013)
whisper_full_with_state: language prob: be (p = 0.000011)
whisper_full_with_state: language prob: ps (p = 0.000011)
whisper_full_with_state: language prob: pa (p = 0.000008)
whisper_full_with_state: language prob: mt (p = 0.000006)
whisper_full_with_state: language prob: mr (p = 0.000006)
whisper_full_with_state: language prob: te (p = 0.000006)
whisper_full_with_state: language prob: sk (p = 0.000005)
whisper_full_with_state: language prob: hy (p = 0.000005)
whisper_full_with_state: language prob: ne (p = 0.000005)
whisper_full_with_state: language prob: mn (p = 0.000004)
whisper_full_with_state: language prob: kk (p = 0.000003)
whisper_full_with_state: language prob: eu (p = 0.000003)
whisper_full_with_state: language prob: lo (p = 0.000003)
whisper_full_with_state: language prob: et (p = 0.000003)
whisper_full_with_state: language prob: yue (p = 0.000002)
whisper_full_with_state: language prob: gu (p = 0.000002)
whisper_full_with_state: language prob: am (p = 0.000002)
whisper_full_with_state: language prob: so (p = 0.000001)
whisper_full_with_state: language prob: as (p = 0.000001)
whisper_full_with_state: language prob: ln (p = 0.000001)
whisper_full_with_state: language prob: ka (p = 0.000001)
whisper_full_with_state: language prob: kn (p = 0.000001)
whisper_full_with_state: language prob: tt (p = 0.000001)
whisper_full_with_state: language prob: tg (p = 0.000000)
whisper_full_with_state: language prob: ha (p = 0.000000)
whisper_full_with_state: language prob: lb (p = 0.000000)
whisper_full_with_state: language prob: su (p = 0.000000)
whisper_full_with_state: language prob: mg (p = 0.000000)
whisper_full_with_state: language prob: tk (p = 0.000000)
whisper_full_with_state: language prob: ba (p = 0.000000)
whisper_full_with_state: language prob: uz (p = 0.000000)
```