### PR TITLE
stream: add `file_mode` option

### DIFF
--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -371,8 +371,7 @@ int main(int argc, char ** argv) {
 
             // print result;
             {
-                const bool capture_iteration = params.fname_out.length() > 0 && (params.file_mode != 0);
-                if (capture_iteration) {
+                if (params.fname_out.length() > 0 && (params.file_mode != 0)) {
                     file_buffer.clear();
                 }
 
@@ -401,7 +400,7 @@ int main(int argc, char ** argv) {
                         fflush(stdout);
 
                         if (params.fname_out.length() > 0) {
-                            if (capture_iteration) {
+                            if (params.file_mode != 0) {
                                 file_buffer += text;
                             } else {
                                 fout << text;
@@ -423,7 +422,7 @@ int main(int argc, char ** argv) {
                         fflush(stdout);
 
                         if (params.fname_out.length() > 0) {
-                            if (capture_iteration) {
+                            if (params.file_mode != 0) {
                                 file_buffer += output;
                             } else {
                                 fout << output;
@@ -433,7 +432,7 @@ int main(int argc, char ** argv) {
                 }
 
                 if (params.fname_out.length() > 0) {
-                    if (capture_iteration) {
+                    if (params.file_mode != 0) {
                         file_buffer.push_back('\n');
                     } else {
                         fout << std::endl;


### PR DESCRIPTION
Related issue: https://github.com/ggml-org/whisper.cpp/issues/1056

Add a `--file_mode` option to the stream example. This feature works together with the `--file` option.
- `raw`: Writes every iteration, so it captures pre‑newline interim tokens, which are continuously overwritten on the terminal. (noisy, current behavior)
- `newline`: Buffers and writes only at the newline boundary, This drops all pre-newline tokens and records only the finalized line.
    - With a **high** `n_new_line` value (large length/step), this mode behaves quite differently from raw.
    - With a **low** `n_new_line` value, the difference is smaller.

Origin issue mentioned clearing last line of file. This might be implemented with `overwrite` mode in the future.
