### PR TITLE
Fixed scalar ggml_vec_cvar_f32

### DIFF
--- a/ggml/src/ggml-cpu/vec.cpp
+++ b/ggml/src/ggml-cpu/vec.cpp
@@ -463,9 +463,8 @@ ggml_float ggml_vec_cvar_f32(const int n, float * y, const float * x, const floa
 #endif
     for (; i < n; ++i) {
         float val = x[i] - mean;
-        val *= val;
-        sum += (ggml_float)val;
         y[i] = val;
+        sum += (ggml_float)(val*val);
     }
     return sum/n;
 }


### PR DESCRIPTION
Hello @ggerganov, @taronaeo,

While upgrading from **whisper.cpp v1.8.0 → v1.8.1**, I noticed that the **non-SIMD (scalar)** code path started producing incorrect results in [whisper.net CI](https://github.com/sandrohanea/whisper.net/actions/runs/18502529281/job/52723199403).
The last successful run was just before commit [d83fef35](https://github.com/ggml-org/whisper.cpp/commit/d83fef35dfc48a2a5d35f46b4a999b768e37c32e), which introduced the new `ggml_vec_cvar_f32` optimization ([llama.cpp PR #15953](https://github.com/ggml-org/llama.cpp/pull/15953)).

After this change, the scalar branch wrote the **squared residuals** into `y[i]` instead of the **centered values**.
This caused normalization in `ggml_compute_forward_norm_f32` to divide `(x − mean)²` by `√(var + eps)` instead of `(x − mean)`, producing invalid activations (resulting in `-inf` logits and `!!!!!!` transcriptions).

The SIMD branches (AVX/SSE/NEON/VXE) were unaffected because they correctly stored the centered values before squaring for the sum.

This PR restores the correct behavior for the scalar path:

```c
for (; i < n; ++i) {
    float d = x[i] - mean;
    y[i] = d;
    sum += (ggml_float)(d * d);
}
```

Verified in [this pipeline run](https://github.com/sandrohanea/whisper.net/actions/runs/18503467062/job/52726462086) — whisper.net now produces expected transcriptions again.
