### PR TITLE
WASM example broken for Hebrew

### DIFF
--- a/examples/whisper.wasm/index-tmpl.html
+++ b/examples/whisper.wasm/index-tmpl.html
@@ -144,7 +144,7 @@
                             <option value="de">German</option>
                             <option value="el">Greek</option>
                             <option value="gu">Gujarati</option>
-                            <option value="iw">Hebrew</option>
+                            <option value="he">Hebrew</option>
                             <option value="hi">Hindi</option>
                             <option value="hu">Hungarian</option>
                             <option value="is">Icelandic</option>


### PR DESCRIPTION
The ID for the Hebrew language is invalid, correct ID is "he".
`whisper_lang_id: unknown language 'iw'`