### PR TITLE
examples : fix typo in vad-speech-segments command [no ci]

### DIFF
--- a/examples/vad-speech-segments/README.md
+++ b/examples/vad-speech-segments/README.md
@@ -15,7 +15,7 @@ The examples can be run using the following command, which uses a model
 that we use internally for testing:
 ```console
 ./build/bin/vad-speech-segments \
-    -vad-model models/for-tests-silero-v6.2.0-ggml.bin \
+    --vad-model models/for-tests-silero-v6.2.0-ggml.bin \
     --file samples/jfk.wav \
     --no-prints
 


### PR DESCRIPTION
This commit corrects a typo the command-line argument for specifying the VAD model in the vad-speech-segments example.