### PR TITLE
vad : fix buffer overflow in sample reduction loop

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6693,7 +6693,7 @@ static bool whisper_vad(
             }
 
             segment_start_samples = std::min(segment_start_samples, n_samples - 1);
-            segment_end_samples = std::min(segment_end_samples, n_samples);
+            segment_end_samples = std::min(segment_end_samples, n_samples - 1);
             int segment_length = segment_end_samples - segment_start_samples;
             if (segment_length > 0) {
                 whisper_state::vad_segment_info segment;


### PR DESCRIPTION
## Summary

Fix heap corruption crash in VAD processing caused by buffer overflow in the sample reduction loop.

## Problem

The buffer size calculation loop (line ~6661) uses `n_samples - 1` as the upper bound:
```cpp
segment_end_samples = std::min(segment_end_samples, n_samples - 1);
filtered_n_samples  += (segment_end_samples - segment_start_samples);
```

But the copy loop (line 6696) uses `n_samples`:
```cpp
segment_end_samples = std::min(segment_end_samples, n_samples);  // BUG: inconsistent bound
int segment_length = segment_end_samples - segment_start_samples;
```

This allows `segment_length` to be up to 1 sample larger per segment than what was allocated, causing writes past the end of `filtered_samples` buffer.

## Symptom

- `malloc(): corrupted top size`
- `malloc(): invalid size (unsorted)`
- Crashes after VAD completes: `whisper_vad: Reduced audio from X to Y samples`
- Intermittent (depends on heap layout)

## Fix

Use consistent bounds (`n_samples - 1`) in both loops.

Fixes #3403