### PR TITLE
Fix FreeBSD linker error: undefined reference to pthread_create

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,8 @@ if (WHISPER_EXTRA_FLAGS)
     target_compile_options(whisper PRIVATE ${WHISPER_EXTRA_FLAGS})
 endif()
 
-target_link_libraries(whisper PUBLIC ggml)
+find_package(Threads REQUIRED)
+target_link_libraries(whisper PUBLIC ggml Threads::Threads)
 
 if (WHISPER_COREML)
     target_link_libraries(whisper PRIVATE whisper.coreml)


### PR DESCRIPTION
On FreeBSD (and strict linkers), libwhisper fails to link because it uses pthreads but does not explicitly link against Threads::Threads. This causes errors with --no-allow-shlib-undefined. This patch explicitly links the whisper target to Threads::Threads.