### PR TITLE
ggml : don't call undefined function

### DIFF
--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -513,7 +513,7 @@ void ggml_gemv_q4_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD) && defined(__ARM_FEATURE_MATMUL_INT8)
     constexpr int    col_groups = ncols_interleaved / 4; // 0123 and 4567
     const uint8x16_t m4b        = vdupq_n_u8(0x0f);
 
@@ -652,7 +652,7 @@ void ggml_gemv_q4_K_8x8_q8_K(int                        n,
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD) && defined(__ARM_FEATURE_MATMUL_INT8)
     constexpr int    col_pairs = ncols_interleaved / 2;
     const uint8x16_t m4b       = vdupq_n_u8(0x0f);
 
@@ -2217,7 +2217,7 @@ void ggml_gemm_q4_K_8x4_q8_K(int n, float * GGML_RESTRICT s, size_t bs, const vo
     UNUSED(ncols_interleaved);
     UNUSED(blocklen);
 
-#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD)
+#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_DOTPROD) && defined(__ARM_FEATURE_MATMUL_INT8)
     constexpr int    q8_k_blocklen = 4;
     constexpr int    acc_size  = 2 * 4;  // 2 row pairs × 4 col pairs
     const uint8x16_t m4b       = vdupq_n_u8(0x0f);


### PR DESCRIPTION
Hi,

Since f0c9017a2f5913b68295e7be9444f79e0c7de7eb, `decode_q4_Kx8_scales_mins` function is not defined in some case but is potentially called in, for instance, `ggml_gemv_q4_K_8x4_q8_K` etc. This patch prevents call for the function if it is not defined.

You encounter this problem on Apple Silicon Mac in a case of:

```
% export SOURCE_DATE_EPOCH=315619200
% cmake -B build
% cmake --build build --config Release                                                                                                                                       14:50 [4/9899]
[  1%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml.c.o
[  3%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml.cpp.o
[  4%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-alloc.c.o
[  6%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-backend.cpp.o
[  8%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-opt.cpp.o
[  9%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/ggml-threading.cpp.o
[ 11%] Building C object ggml/src/CMakeFiles/ggml-base.dir/ggml-quants.c.o
[ 12%] Building CXX object ggml/src/CMakeFiles/ggml-base.dir/gguf.cpp.o
[ 14%] Linking CXX shared library libggml-base.dylib
[ 14%] Built target ggml-base
[ 16%] Generate assembly for embedded Metal library
Embedding Metal library
[ 17%] Building CXX object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal.cpp.o
[ 19%] Building C object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal-device.m.o
[ 20%] Building CXX object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal-device.cpp.o
[ 22%] Building CXX object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal-common.cpp.o
[ 24%] Building C object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal-context.m.o
[ 25%] Building CXX object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/ggml-metal-ops.cpp.o
[ 27%] Building ASM object ggml/src/ggml-metal/CMakeFiles/ggml-metal.dir/__/__/__/autogenerated/ggml-metal-embed.s.o
[ 29%] Linking CXX shared library libggml-metal.dylib
[ 29%] Built target ggml-metal
[ 30%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.c.o
[ 32%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ggml-cpu.cpp.o
[ 33%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/repack.cpp.o
[ 35%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/hbm.cpp.o
[ 37%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/quants.c.o
[ 38%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/traits.cpp.o
[ 40%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/amx.cpp.o
[ 41%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/amx/mmq.cpp.o
[ 43%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/binary-ops.cpp.o
[ 45%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/unary-ops.cpp.o
[ 46%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/vec.cpp.o
[ 48%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/ops.cpp.o
[ 50%] Building C object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/arm/quants.c.o
[ 51%] Building CXX object ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/arm/repack.cpp.o
/Users/kitaitimakoto/src/github.com/ggml-org/whisper.cpp/ggml/src/ggml-cpu/arch/arm/repack.cpp:564:21: error: use of undeclared identifier 'decode_q4_Kx8_scales_mins'
  564 |                     decode_q4_Kx8_scales_mins(&q4_ptr[b].scales[offset], &q4sb_mins[i], aux_q4sb);
      |                     ^
/Users/kitaitimakoto/src/github.com/ggml-org/whisper.cpp/ggml/src/ggml-cpu/arch/arm/repack.cpp:704:21: error: use of undeclared identifier 'decode_q4_Kx8_scales_mins'
  704 |                     decode_q4_Kx8_scales_mins(&q4_ptr[b].scales[offset], &q4sb_mins[i], aux_q4sb);
      |                     ^
/Users/kitaitimakoto/src/github.com/ggml-org/whisper.cpp/ggml/src/ggml-cpu/arch/arm/repack.cpp:2307:25: error: use of undeclared identifier 'decode_q4_Kx8_scales_mins'
 2307 |                         decode_q4_Kx8_scales_mins(&q4_ptr[b].scales[offset], &q4sb_mins[i], aux_q4sb);
      |                         ^
3 errors generated.
make[2]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/ggml-cpu/arch/arm/repack.cpp.o] Error 1
make[1]: *** [ggml/src/CMakeFiles/ggml-cpu.dir/all] Error 2
make: *** [all] Error 2
```
Setting `SOURCE_DATE_EPOCH` dsiables `GGML_NATIVE` and that causes this error.

This causes installation problem for Ruby bindings on Apple Silicon Mac. I'm not sure whether this fix is appropriate, but want to fix the problem. Can you review it? 

Environment:

* commit: 2551e4ce98db69027d08bd99bcc3f1a4e2ad2cef
* `uname -a`: `Darwin Mac.lan 25.1.0 Darwin Kernel Version 25.1.0: Mon Oct 20 19:34:03 PDT 2025; root:xnu-12377.41.6~2/RELEASE_ARM64_T8112 arm64`