### PR TITLE
Fix compilation error on ARM64 (undeclared decode_q4_Kx8_scales_mins)

### DIFF
--- a/ggml/src/ggml-cpu/arch/arm/repack.cpp
+++ b/ggml/src/ggml-cpu/arch/arm/repack.cpp
@@ -24,7 +24,7 @@
 
 #define UNUSED GGML_UNUSED
 
-#if defined(__aarch64__) && defined(__ARM_NEON) && defined(__ARM_FEATURE_MATMUL_INT8)
+#if defined(__aarch64__) && defined(__ARM_NEON) && (defined(__ARM_FEATURE_MATMUL_INT8) || defined(__ARM_FEATURE_DOTPROD))
 static inline void decode_q4_Kx8_scales_mins(const uint8_t * scales_in,
                                              int16x8_t *     out_mins,
                                              int8_t *        out_scales) {


### PR DESCRIPTION
The build was failing on ARM64 systems (specifically macOS Apple Silicon) with the error:

`
[error: use of undeclared identifier 'decode_q4_Kx8_scales_mins']
`

Updated the preprocessor guard for the definition of decode_q4_Kx8_scales_mins to ensure it is available if either __ARM_FEATURE_MATMUL_INT8 OR __ARM_FEATURE_DOTPROD is present.

