### PR TITLE
cli: use NotoMono-Regular.ttf font in Linux

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -82,7 +82,11 @@ struct whisper_params {
 
     std::string language  = "en";
     std::string prompt;
+#ifdef __linux__
+    std::string font_path = "/usr/share/fonts/truetype/noto/NotoMono-Regular.ttf";
+#else
     std::string font_path = "/System/Library/Fonts/Supplemental/Courier New Bold.ttf";
+#endif
     std::string model     = "models/ggml-base.en.bin";
     std::string grammar;
     std::string grammar_rule;


### PR DESCRIPTION
E. g. in Debian this font is in `fonts-noto-mono` package.

After this patch:

<img width="1400" height="915" alt="Screenshot_20251227_194030" src="https://github.com/user-attachments/assets/3cac8e37-4e2f-4dd9-803e-df1d03208430" />
