### PR TITLE
Fix: added <cmath>

### DIFF
--- a/ggml/src/ggml-cuda/fattn-common.cuh
+++ b/ggml/src/ggml-cuda/fattn-common.cuh
@@ -4,6 +4,7 @@
 #include "convert.cuh"
 #include "vecdotq.cuh"
 
+#include <cmath>
 #include <cstdint>
 
 #define FATTN_KQ_STRIDE       256
@@ -595,7 +596,7 @@ static __global__ void flash_attn_mask_to_KV_max(
 #pragma unroll
         for (int j = 0; j < ncols1; ++j) {
             const float2 tmp = __half22float2(mask[j*s31 + KV_max_sj/2 + tid]);
-            all_inf = all_inf && int(isinf(tmp.x)) && int(isinf(tmp.y));
+            all_inf = all_inf && int(std::isinf(tmp.x)) && int(std::isinf(tmp.y));
         }
 
         all_inf = warp_reduce_all(all_inf);


### PR DESCRIPTION
```
fattn-common.cuh: In function 'void flash_attn_mask_to_KV_max(const half2*, int*, int, int, int)':
fattn-common.cuh:599:38: error: there are no arguments to 'isinf' that depend on a template parameter, so a declaration of 'isinf' must be available [-Wtemplate-body]
  599 |             all_inf = all_inf && int(isinf(tmp.x)) && int(isinf(tmp.y));
      |                                      ^~~~~
fattn-common.cuh:599:38: note: (if you use '-fpermissive', G++ will accept your code, but allowing the use of an undeclared name is deprecated)
fattn-common.cuh:599:59: error: there are no arguments to 'isinf' that depend on a template parameter, so a declaration of 'isinf' must be available [-Wtemplate-body]
  599 |             all_inf = all_inf && int(isinf(tmp.x)) && int(isinf(tmp.y));
      |                                                           ^~~~~
```