### PR TITLE
Fix: added flags

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3246,7 +3246,7 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
 
             for (int i = 1; i <= concurrent_event->n_streams; ++i) {
                 cudaStream_t stream = cuda_ctx->stream(cuda_ctx->device, i);
-                CUDA_CHECK(cudaStreamWaitEvent(stream, concurrent_event->fork_event));
+                CUDA_CHECK(cudaStreamWaitEvent(stream, concurrent_event->fork_event, 0));
             }
         }
     };
@@ -3327,7 +3327,7 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
                             // Wait on join events of forked streams in the main stream
                             CUDA_CHECK(cudaEventRecord(concurrent_event->join_events[i - 1],
                                                        cuda_ctx->stream(cuda_ctx->device, i)));
-                            CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->join_events[i - 1]));
+                            CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->join_events[i - 1], 0));
                         }
 
                         is_concurrent_event_active = false;


### PR DESCRIPTION
```
In file included from ggml-cuda.cu:5:
ggml-cuda.cu: In function 'void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context*, ggml_cgraph*, bool&, bool&, bool&)':
ggml-cuda.cu:3330:59: error: too few arguments to function 'cudaError_t cudaStreamWaitEvent(cudaStream_t, cudaEvent_t, unsigned int)'
 3330 |                             CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->join_events[i - 1]));
      |                                        ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
common.cuh:165:22: note: in definition of macro 'CUDA_CHECK_GEN'
  165 |         auto err_ = (err);                                                          \
      |                      ^~~
ggml-cuda.cu:3330:29: note: in expansion of macro 'CUDA_CHECK'
 3330 |                             CUDA_CHECK(cudaStreamWaitEvent(cuda_ctx->stream(), concurrent_event->join_events[i - 1]));
      |                             ^~~~~~~~~~
In file included from C:/gcc1520/x86_64-w64-mingw32/include/cudart/channel_descriptor.h:61,
                 from C:/gcc1520/x86_64-w64-mingw32/include/cudart/cuda_runtime.h:94,
                 from <command-line>:
C:/gcc1520/x86_64-w64-mingw32/include/cudart/cuda_runtime_api.h:14842:62: note: declared here
14842 |     extern __host__ __cudart_builtin__ cudaError_t CUDARTAPI cudaStreamWaitEvent(cudaStream_t stream, cudaEvent_t event, unsigned int flags);
      |                                                              ^~~~~~~~~~~~~~~~~~~
```