### PR TITLE
vulkan: fix SIGSEGV on Android when using buffer_device_address

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -4794,7 +4794,9 @@ static vk_device ggml_vk_get_device(size_t idx) {
             throw std::runtime_error("Unsupported device");
         }
 
-        device_extensions.push_back("VK_KHR_16bit_storage");
+        if (fp16_storage) {
+            device_extensions.push_back("VK_KHR_16bit_storage");
+        }
 
 #ifdef GGML_VULKAN_VALIDATE
         device_extensions.push_back("VK_KHR_shader_non_semantic_info");


### PR DESCRIPTION
vkGetBufferDeviceAddress is not loaded without explicit VK_KHR_buffer_device_address extension

Also init disaptcher with device as (optionally) documented in https://github.com/KhronosGroup/Vulkan-Hpp?tab=readme-ov-file#extensions--per-device-function-pointers-

```
  ********** Crash dump: **********
  #00 0x0000000000000000 <unknown>
  #01 0x000000000317c7b4 libggml-vulkan.so
      vk::Device::getBufferAddress<vk::DispatchLoaderDynamic>(vk::BufferDeviceAddressInfo const&, vk::DispatchLoaderDynamic const&) const
      vulkan/vulkan_funcs.hpp:6563:30
      ggml_vk_create_buffer(std::shared_ptr<vk_device_struct>&, unsigned long, std::initializer_list<vk::Flags<vk::MemoryPropertyFlagBits>> const&)
      ggml/src/ggml-vulkan/ggml-vulkan.cpp:2469:40
  #02 0x000000000317b728 libggml-vulkan.so
      ggml_vk_create_buffer_device(std::shared_ptr<vk_device_struct>&, unsigned long)
      ggml/src/ggml-vulkan/ggml-vulkan.cpp:2497:19
  #03 0x000000000317b4b0 libggml-vulkan.so
      ggml_backend_vk_buffer_type_alloc_buffer(ggml_backend_buffer_type*, unsigned long)
      ggml/src/ggml-vulkan/ggml-vulkan.cpp:12591:22
  #04 0x000000000006f3a8 libggml-base.so
      alloc_tensor_range
      ggml/src/ggml-alloc.c:1135:36
  #05 0x000000000006e608 libggml-base.so
      ggml_backend_alloc_ctx_tensors_from_buft_impl
      ggml/src/ggml-alloc.c:1206:27
  #06 0x000000000006e70c libggml-base.so
      ggml_backend_alloc_ctx_tensors_from_buft
      ggml/src/ggml-alloc.c:1244:12
  #07 0x0000000000037d04 libwhisper.so
      whisper_model_load(whisper_model_loader*, whisper_context&)
      src/whisper.cpp:1852:37
  #08 0x000000000003653c libwhisper.so
      whisper_init_with_params_no_state
      src/whisper.cpp:3723:10
  #09 0x0000000000038768 libwhisper.so
      whisper_init_with_params
      src/whisper.cpp:3766:29
```

**Android arm64:**
```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.3.336


Instance Extensions: count = 12
===============================
	VK_EXT_debug_report                    : extension revision 10
	VK_EXT_swapchain_colorspace            : extension revision 4
	VK_GOOGLE_surfaceless_query            : extension revision 1
	VK_KHR_android_surface                 : extension revision 6
	VK_KHR_device_group_creation           : extension revision 1
	VK_KHR_external_fence_capabilities     : extension revision 1
	VK_KHR_external_memory_capabilities    : extension revision 1
	VK_KHR_external_semaphore_capabilities : extension revision 1
	VK_KHR_get_physical_device_properties2 : extension revision 2
	VK_KHR_get_surface_capabilities2       : extension revision 1
	VK_KHR_surface                         : extension revision 25
	VK_KHR_surface_protected_capabilities  : extension revision 1

Layers:
=======
Device Properties and Extensions:
=================================
GPU0:
VkPhysicalDeviceProperties:
---------------------------
	apiVersion        = 1.1.177 (4198577)
	driverVersion     = 32.1.0 (134221824)
	vendorID          = 0x13b5
	deviceID          = 0xa8620004
	deviceType        = PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU
	deviceName        = Mali-G710 MC10
	pipelineCacheUUID = f86d59c9-68d9-213b-b3dc-75cc1ae75f86

VkPhysicalDeviceLimits:
-----------------------
	maxImageDimension1D                             = 32768
	maxImageDimension2D                             = 32768
	maxImageDimension3D                             = 32768
	maxImageDimensionCube                           = 32768
	maxImageArrayLayers                             = 4096
	maxTexelBufferElements                          = 268435456
	maxUniformBufferRange                           = 65536
	maxStorageBufferRange                           = 268435456
	maxPushConstantsSize                            = 256
	maxMemoryAllocationCount                        = 4294967295
	maxSamplerAllocationCount                       = 4294967295
	bufferImageGranularity                          = 0x00001000
	sparseAddressSpaceSize                          = 0x00000000
	maxBoundDescriptorSets                          = 4
	maxPerStageDescriptorSamplers                   = 500000
	maxPerStageDescriptorUniformBuffers             = 36
	maxPerStageDescriptorStorageBuffers             = 500000
	maxPerStageDescriptorSampledImages              = 500000
	maxPerStageDescriptorStorageImages              = 500000
	maxPerStageDescriptorInputAttachments           = 9
	maxPerStageResources                            = 500000
	maxDescriptorSetSamplers                        = 500000
	maxDescriptorSetUniformBuffers                  = 216
	maxDescriptorSetUniformBuffersDynamic           = 32
	maxDescriptorSetStorageBuffers                  = 500000
	maxDescriptorSetStorageBuffersDynamic           = 32
	maxDescriptorSetSampledImages                   = 500000
	maxDescriptorSetStorageImages                   = 500000
	maxDescriptorSetInputAttachments                = 9
	maxVertexInputAttributes                        = 32
	maxVertexInputBindings                          = 32
	maxVertexInputAttributeOffset                   = 2047
	maxVertexInputBindingStride                     = 2048
	maxVertexOutputComponents                       = 128
	maxTessellationGenerationLevel                  = 64
	maxTessellationPatchSize                        = 32
	maxTessellationControlPerVertexInputComponents  = 128
	maxTessellationControlPerVertexOutputComponents = 128
	maxTessellationControlPerPatchOutputComponents  = 120
	maxTessellationControlTotalOutputComponents     = 4096
	maxTessellationEvaluationInputComponents        = 128
	maxTessellationEvaluationOutputComponents       = 128
	maxGeometryShaderInvocations                    = 32
	maxGeometryInputComponents                      = 64
	maxGeometryOutputComponents                     = 128
	maxGeometryOutputVertices                       = 256
	maxGeometryTotalOutputComponents                = 1024
	maxFragmentInputComponents                      = 128
	maxFragmentOutputAttachments                    = 8
	maxFragmentDualSrcAttachments                   = 0
	maxFragmentCombinedOutputResources              = 1000008
	maxComputeSharedMemorySize                      = 32768
	maxComputeWorkGroupCount: count = 3
		4294967295
		4294967295
		4294967295
	maxComputeWorkGroupInvocations                  = 1024
	maxComputeWorkGroupSize: count = 3
		1024
		1024
		1024
	subPixelPrecisionBits                           = 8
	subTexelPrecisionBits                           = 8
	mipmapPrecisionBits                             = 8
	maxDrawIndexedIndexValue                        = 4294967295
	maxDrawIndirectCount                            = 4294967295
	maxSamplerLodBias                               = 255
	maxSamplerAnisotropy                            = 16
	maxViewports                                    = 1
	maxViewportDimensions: count = 2
		32768
		32768
	viewportBoundsRange: count = 2
		-65536
		65535
	viewportSubPixelBits                            = 0
	minMemoryMapAlignment                           = 64
	minTexelBufferOffsetAlignment                   = 0x00000040
	minUniformBufferOffsetAlignment                 = 0x00000010
	minStorageBufferOffsetAlignment                 = 0x00000040
	minTexelOffset                                  = -8
	maxTexelOffset                                  = 7
	minTexelGatherOffset                            = -8
	maxTexelGatherOffset                            = 7
	minInterpolationOffset                          = -0.5
	maxInterpolationOffset                          = 0.5
	subPixelInterpolationOffsetBits                 = 4
	maxFramebufferWidth                             = 32768
	maxFramebufferHeight                            = 32768
	maxFramebufferLayers                            = 256
	framebufferColorSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferDepthSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferStencilSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferNoAttachmentsSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	maxColorAttachments                             = 8
	sampledImageColorSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageIntegerSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageDepthSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageStencilSampleCounts: count = 4
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	storageImageSampleCounts: count = 1
		SAMPLE_COUNT_1_BIT
	maxSampleMaskWords                              = 1
	timestampComputeAndGraphics                     = true
	timestampPeriod                                 = 76.9231
	maxClipDistances                                = 0
	maxCullDistances                                = 0
	maxCombinedClipAndCullDistances                 = 0
	discreteQueuePriorities                         = 2
	pointSizeRange: count = 2
		1
		1024
	lineWidthRange: count = 2
		1
		1
	pointSizeGranularity                            = 0.0625
	lineWidthGranularity                            = 0
	strictLines                                     = true
	standardSampleLocations                         = true
	optimalBufferCopyOffsetAlignment                = 0x00000040
	optimalBufferCopyRowPitchAlignment              = 0x00000040
	nonCoherentAtomSize                             = 0x00000040

VkPhysicalDeviceSparseProperties:
---------------------------------
	residencyStandard2DBlockShape            = false
	residencyStandard2DMultisampleBlockShape = false
	residencyStandard3DBlockShape            = false
	residencyAlignedMipSize                  = false
	residencyNonResidentStrict               = false

VkPhysicalDeviceCustomBorderColorPropertiesEXT:
-----------------------------------------------
	maxCustomBorderColorSamplers = 4294967295

VkPhysicalDeviceDepthStencilResolvePropertiesKHR:
-------------------------------------------------
	supportedDepthResolveModes: count = 1
		RESOLVE_MODE_SAMPLE_ZERO_BIT
	supportedStencilResolveModes: count = 1
		RESOLVE_MODE_SAMPLE_ZERO_BIT
	independentResolveNone = false
	independentResolve     = false

VkPhysicalDeviceDescriptorIndexingPropertiesEXT:
------------------------------------------------
	maxUpdateAfterBindDescriptorsInAllPools              = 4294967295
	shaderUniformBufferArrayNonUniformIndexingNative     = false
	shaderSampledImageArrayNonUniformIndexingNative      = false
	shaderStorageBufferArrayNonUniformIndexingNative     = true
	shaderStorageImageArrayNonUniformIndexingNative      = false
	shaderInputAttachmentArrayNonUniformIndexingNative   = false
	robustBufferAccessUpdateAfterBind                    = true
	quadDivergentImplicitLod                             = false
	maxPerStageDescriptorUpdateAfterBindSamplers         = 500000
	maxPerStageDescriptorUpdateAfterBindUniformBuffers   = 36
	maxPerStageDescriptorUpdateAfterBindStorageBuffers   = 500000
	maxPerStageDescriptorUpdateAfterBindSampledImages    = 500000
	maxPerStageDescriptorUpdateAfterBindStorageImages    = 500000
	maxPerStageDescriptorUpdateAfterBindInputAttachments = 9
	maxPerStageUpdateAfterBindResources                  = 500000
	maxDescriptorSetUpdateAfterBindSamplers              = 500000
	maxDescriptorSetUpdateAfterBindUniformBuffers        = 216
	maxDescriptorSetUpdateAfterBindUniformBuffersDynamic = 32
	maxDescriptorSetUpdateAfterBindStorageBuffers        = 500000
	maxDescriptorSetUpdateAfterBindStorageBuffersDynamic = 32
	maxDescriptorSetUpdateAfterBindSampledImages         = 500000
	maxDescriptorSetUpdateAfterBindStorageImages         = 500000
	maxDescriptorSetUpdateAfterBindInputAttachments      = 9

VkPhysicalDeviceDriverPropertiesKHR:
------------------------------------
	driverID   = DRIVER_ID_ARM_PROPRIETARY
	driverName = Mali-G710 MC10
	driverInfo = v1.r32p1-01eac0.55ce131ae332d8a4a1eb9e0a95da701c
	conformanceVersion:
		major    = 1
		minor    = 2
		subminor = 6
		patch    = 0

VkPhysicalDeviceFloatControlsPropertiesKHR:
-------------------------------------------
	denormBehaviorIndependence            = SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL
	roundingModeIndependence              = SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL
	shaderSignedZeroInfNanPreserveFloat16 = true
	shaderSignedZeroInfNanPreserveFloat32 = true
	shaderSignedZeroInfNanPreserveFloat64 = false
	shaderDenormPreserveFloat16           = true
	shaderDenormPreserveFloat32           = true
	shaderDenormPreserveFloat64           = false
	shaderDenormFlushToZeroFloat16        = true
	shaderDenormFlushToZeroFloat32        = true
	shaderDenormFlushToZeroFloat64        = false
	shaderRoundingModeRTEFloat16          = true
	shaderRoundingModeRTEFloat32          = true
	shaderRoundingModeRTEFloat64          = false
	shaderRoundingModeRTZFloat16          = true
	shaderRoundingModeRTZFloat32          = true
	shaderRoundingModeRTZFloat64          = false

VkPhysicalDeviceFragmentDensityMap2PropertiesEXT:
-------------------------------------------------
	subsampledLoads                           = false
	subsampledCoarseReconstructionEarlyAccess = true
	maxSubsampledArrayLayers                  = 4096
	maxDescriptorSetSubsampledSamplers        = 8

VkPhysicalDeviceFragmentDensityMapPropertiesEXT:
------------------------------------------------
	minFragmentDensityTexelSize:
		width  = 32
		height = 32
	maxFragmentDensityTexelSize:
		width  = 32
		height = 32
	fragmentDensityInvocations = true

VkPhysicalDeviceInlineUniformBlockPropertiesEXT:
------------------------------------------------
	maxInlineUniformBlockSize                               = 65536
	maxPerStageDescriptorInlineUniformBlocks                = 4
	maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks = 4
	maxDescriptorSetInlineUniformBlocks                     = 4
	maxDescriptorSetUpdateAfterBindInlineUniformBlocks      = 4

VkPhysicalDeviceLineRasterizationPropertiesEXT:
-----------------------------------------------
	lineSubPixelPrecisionBits = 8

VkPhysicalDeviceProvokingVertexPropertiesEXT:
---------------------------------------------
	provokingVertexModePerPipeline                       = false
	transformFeedbackPreservesTriangleFanProvokingVertex = false

VkPhysicalDeviceSamplerFilterMinmaxPropertiesEXT:
-------------------------------------------------
	filterMinmaxSingleComponentFormats = true
	filterMinmaxImageComponentMapping  = true

VkPhysicalDeviceSubgroupSizeControlPropertiesEXT:
-------------------------------------------------
	minSubgroupSize              = 16
	maxSubgroupSize              = 16
	maxComputeWorkgroupSubgroups = 64
	requiredSubgroupSizeStages: count = 2
		SHADER_STAGE_FRAGMENT_BIT
		SHADER_STAGE_COMPUTE_BIT

VkPhysicalDeviceTimelineSemaphorePropertiesKHR:
-----------------------------------------------
	maxTimelineSemaphoreValueDifference = 18446744073709551615

VkPhysicalDeviceTransformFeedbackPropertiesEXT:
-----------------------------------------------
	maxTransformFeedbackStreams                = 1
	maxTransformFeedbackBuffers                = 4
	maxTransformFeedbackBufferSize             = 0x10000000
	maxTransformFeedbackStreamDataSize         = 512
	maxTransformFeedbackBufferDataSize         = 512
	maxTransformFeedbackBufferDataStride       = 512
	transformFeedbackQueries                   = true
	transformFeedbackStreamsLinesTriangles     = false
	transformFeedbackRasterizationStreamSelect = false
	transformFeedbackDraw                      = false

Device Extensions: count = 71
	VK_ANDROID_external_memory_android_hardware_buffer : extension revision 3
	VK_EXT_4444_formats                                : extension revision 1
	VK_EXT_astc_decode_mode                            : extension revision 1
	VK_EXT_calibrated_timestamps                       : extension revision 2
	VK_EXT_custom_border_color                         : extension revision 12
	VK_EXT_descriptor_indexing                         : extension revision 2
	VK_EXT_device_memory_report                        : extension revision 2
	VK_EXT_external_memory_dma_buf                     : extension revision 1
	VK_EXT_fragment_density_map                        : extension revision 1
	VK_EXT_fragment_density_map2                       : extension revision 1
	VK_EXT_global_priority                             : extension revision 2
	VK_EXT_hdr_metadata                                : extension revision 2
	VK_EXT_host_query_reset                            : extension revision 1
	VK_EXT_image_drm_format_modifier                   : extension revision 1
	VK_EXT_image_robustness                            : extension revision 1
	VK_EXT_index_type_uint8                            : extension revision 1
	VK_EXT_inline_uniform_block                        : extension revision 1
	VK_EXT_line_rasterization                          : extension revision 1
	VK_EXT_provoking_vertex                            : extension revision 1
	VK_EXT_queue_family_foreign                        : extension revision 1
	VK_EXT_sampler_filter_minmax                       : extension revision 2
	VK_EXT_scalar_block_layout                         : extension revision 1
	VK_EXT_separate_stencil_usage                      : extension revision 1
	VK_EXT_shader_subgroup_ballot                      : extension revision 1
	VK_EXT_shader_subgroup_vote                        : extension revision 1
	VK_EXT_subgroup_size_control                       : extension revision 2
	VK_EXT_texture_compression_astc_hdr                : extension revision 1
	VK_EXT_transform_feedback                          : extension revision 1
	VK_GOOGLE_display_timing                           : extension revision 1
	VK_KHR_16bit_storage                               : extension revision 1
	VK_KHR_8bit_storage                                : extension revision 1
	VK_KHR_bind_memory2                                : extension revision 1
	VK_KHR_buffer_device_address                       : extension revision 1
	VK_KHR_create_renderpass2                          : extension revision 1
	VK_KHR_dedicated_allocation                        : extension revision 3
	VK_KHR_depth_stencil_resolve                       : extension revision 1
	VK_KHR_descriptor_update_template                  : extension revision 1
	VK_KHR_device_group                                : extension revision 4
	VK_KHR_draw_indirect_count                         : extension revision 1
	VK_KHR_driver_properties                           : extension revision 1
	VK_KHR_external_fence                              : extension revision 1
	VK_KHR_external_fence_fd                           : extension revision 1
	VK_KHR_external_memory                             : extension revision 1
	VK_KHR_external_memory_fd                          : extension revision 1
	VK_KHR_external_semaphore                          : extension revision 1
	VK_KHR_external_semaphore_fd                       : extension revision 1
	VK_KHR_get_memory_requirements2                    : extension revision 1
	VK_KHR_image_format_list                           : extension revision 1
	VK_KHR_imageless_framebuffer                       : extension revision 1
	VK_KHR_incremental_present                         : extension revision 2
	VK_KHR_maintenance1                                : extension revision 2
	VK_KHR_maintenance2                                : extension revision 1
	VK_KHR_maintenance3                                : extension revision 1
	VK_KHR_multiview                                   : extension revision 1
	VK_KHR_relaxed_block_layout                        : extension revision 1
	VK_KHR_sampler_mirror_clamp_to_edge                : extension revision 3
	VK_KHR_sampler_ycbcr_conversion                    : extension revision 14
	VK_KHR_separate_depth_stencil_layouts              : extension revision 1
	VK_KHR_shader_draw_parameters                      : extension revision 1
	VK_KHR_shader_float16_int8                         : extension revision 1
	VK_KHR_shader_float_controls                       : extension revision 4
	VK_KHR_shader_non_semantic_info                    : extension revision 1
	VK_KHR_shader_subgroup_extended_types              : extension revision 1
	VK_KHR_shared_presentable_image                    : extension revision 1
	VK_KHR_spirv_1_4                                   : extension revision 1
	VK_KHR_storage_buffer_storage_class                : extension revision 1
	VK_KHR_swapchain                                   : extension revision 70
	VK_KHR_timeline_semaphore                          : extension revision 2
	VK_KHR_uniform_buffer_standard_layout              : extension revision 1
	VK_KHR_variable_pointers                           : extension revision 1
	VK_KHR_vulkan_memory_model                         : extension revision 3

VkQueueFamilyProperties:
========================
	queueProperties[0]:
	-------------------
		minImageTransferGranularity = (1,1,1)
		queueCount                  = 2
		queueFlags                  = QUEUE_GRAPHICS_BIT | QUEUE_COMPUTE_BIT | QUEUE_TRANSFER_BIT
		timestampValidBits          = 64
		present support             = false

VkPhysicalDeviceMemoryProperties:
=================================
memoryHeaps: count = 1
	memoryHeaps[0]:
		size   = 7448743936 (0x1bbfad000) (6.94 GiB)
		flags: count = 1
			MEMORY_HEAP_DEVICE_LOCAL_BIT
memoryTypes: count = 3
	memoryTypes[0]:
		heapIndex     = 0
		propertyFlags = 0x0007: count = 3
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_COHERENT_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse, non-transient)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse, non-transient)
	memoryTypes[1]:
		heapIndex     = 0
		propertyFlags = 0x000b: count = 3
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_CACHED_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse, non-transient)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse, non-transient)
	memoryTypes[2]:
		heapIndex     = 0
		propertyFlags = 0x0011: count = 2
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
			MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(transient only)
			IMAGE_TILING_LINEAR:
				None

VkPhysicalDeviceFeatures:
=========================
	robustBufferAccess                      = true
	fullDrawIndexUint32                     = true
	imageCubeArray                          = true
	independentBlend                        = true
	geometryShader                          = true
	tessellationShader                      = true
	sampleRateShading                       = true
	dualSrcBlend                            = false
	logicOp                                 = false
	multiDrawIndirect                       = true
	drawIndirectFirstInstance               = true
	depthClamp                              = true
	depthBiasClamp                          = true
	fillModeNonSolid                        = false
	depthBounds                             = false
	wideLines                               = false
	largePoints                             = true
	alphaToOne                              = false
	multiViewport                           = false
	samplerAnisotropy                       = true
	textureCompressionETC2                  = true
	textureCompressionASTC_LDR              = true
	textureCompressionBC                    = false
	occlusionQueryPrecise                   = true
	pipelineStatisticsQuery                 = false
	vertexPipelineStoresAndAtomics          = false
	fragmentStoresAndAtomics                = true
	shaderTessellationAndGeometryPointSize  = false
	shaderImageGatherExtended               = true
	shaderStorageImageExtendedFormats       = true
	shaderStorageImageMultisample           = false
	shaderStorageImageReadWithoutFormat     = true
	shaderStorageImageWriteWithoutFormat    = true
	shaderUniformBufferArrayDynamicIndexing = true
	shaderSampledImageArrayDynamicIndexing  = true
	shaderStorageBufferArrayDynamicIndexing = true
	shaderStorageImageArrayDynamicIndexing  = true
	shaderClipDistance                      = false
	shaderCullDistance                      = false
	shaderFloat64                           = false
	shaderInt64                             = false
	shaderInt16                             = true
	shaderResourceResidency                 = false
	shaderResourceMinLod                    = false
	sparseBinding                           = false
	sparseResidencyBuffer                   = false
	sparseResidencyImage2D                  = false
	sparseResidencyImage3D                  = false
	sparseResidency2Samples                 = false
	sparseResidency4Samples                 = false
	sparseResidency8Samples                 = false
	sparseResidency16Samples                = false
	sparseResidencyAliased                  = false
	variableMultisampleRate                 = false
	inheritedQueries                        = false

VkPhysicalDevice4444FormatsFeaturesEXT:
---------------------------------------
	formatA4R4G4B4 = true
	formatA4B4G4R4 = true

VkPhysicalDevice8BitStorageFeaturesKHR:
---------------------------------------
	storageBuffer8BitAccess           = true
	uniformAndStorageBuffer8BitAccess = true
	storagePushConstant8              = true

VkPhysicalDeviceASTCDecodeFeaturesEXT:
--------------------------------------
	decodeModeSharedExponent = true

VkPhysicalDeviceBufferDeviceAddressFeaturesKHR:
-----------------------------------------------
	bufferDeviceAddress              = true
	bufferDeviceAddressCaptureReplay = false
	bufferDeviceAddressMultiDevice   = false

VkPhysicalDeviceCustomBorderColorFeaturesEXT:
---------------------------------------------
	customBorderColors             = true
	customBorderColorWithoutFormat = true

VkPhysicalDeviceDescriptorIndexingFeaturesEXT:
----------------------------------------------
	shaderInputAttachmentArrayDynamicIndexing          = true
	shaderUniformTexelBufferArrayDynamicIndexing       = true
	shaderStorageTexelBufferArrayDynamicIndexing       = true
	shaderUniformBufferArrayNonUniformIndexing         = true
	shaderSampledImageArrayNonUniformIndexing          = true
	shaderStorageBufferArrayNonUniformIndexing         = true
	shaderStorageImageArrayNonUniformIndexing          = true
	shaderInputAttachmentArrayNonUniformIndexing       = true
	shaderUniformTexelBufferArrayNonUniformIndexing    = true
	shaderStorageTexelBufferArrayNonUniformIndexing    = true
	descriptorBindingUniformBufferUpdateAfterBind      = true
	descriptorBindingSampledImageUpdateAfterBind       = true
	descriptorBindingStorageImageUpdateAfterBind       = true
	descriptorBindingStorageBufferUpdateAfterBind      = true
	descriptorBindingUniformTexelBufferUpdateAfterBind = true
	descriptorBindingStorageTexelBufferUpdateAfterBind = true
	descriptorBindingUpdateUnusedWhilePending          = true
	descriptorBindingPartiallyBound                    = true
	descriptorBindingVariableDescriptorCount           = true
	runtimeDescriptorArray                             = true

VkPhysicalDeviceDeviceMemoryReportFeaturesEXT:
----------------------------------------------
	deviceMemoryReport = true

VkPhysicalDeviceFragmentDensityMap2FeaturesEXT:
-----------------------------------------------
	fragmentDensityMapDeferred = true

VkPhysicalDeviceFragmentDensityMapFeaturesEXT:
----------------------------------------------
	fragmentDensityMap                    = true
	fragmentDensityMapDynamic             = true
	fragmentDensityMapNonSubsampledImages = false

VkPhysicalDeviceHostQueryResetFeaturesEXT:
------------------------------------------
	hostQueryReset = true

VkPhysicalDeviceImageRobustnessFeaturesEXT:
-------------------------------------------
	robustImageAccess = true

VkPhysicalDeviceImagelessFramebufferFeaturesKHR:
------------------------------------------------
	imagelessFramebuffer = true

VkPhysicalDeviceIndexTypeUint8FeaturesEXT:
------------------------------------------
	indexTypeUint8 = true

VkPhysicalDeviceInlineUniformBlockFeaturesEXT:
----------------------------------------------
	inlineUniformBlock                                 = true
	descriptorBindingInlineUniformBlockUpdateAfterBind = true

VkPhysicalDeviceLineRasterizationFeaturesEXT:
---------------------------------------------
	rectangularLines         = true
	bresenhamLines           = true
	smoothLines              = false
	stippledRectangularLines = false
	stippledBresenhamLines   = false
	stippledSmoothLines      = false

VkPhysicalDeviceProvokingVertexFeaturesEXT:
-------------------------------------------
	provokingVertexLast                       = true
	transformFeedbackPreservesProvokingVertex = false

VkPhysicalDeviceScalarBlockLayoutFeaturesEXT:
---------------------------------------------
	scalarBlockLayout = true

VkPhysicalDeviceSeparateDepthStencilLayoutsFeaturesKHR:
-------------------------------------------------------
	separateDepthStencilLayouts = true

VkPhysicalDeviceShaderFloat16Int8FeaturesKHR:
---------------------------------------------
	shaderFloat16 = true
	shaderInt8    = true

VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR:
-------------------------------------------------------
	shaderSubgroupExtendedTypes = true

VkPhysicalDeviceSubgroupSizeControlFeaturesEXT:
-----------------------------------------------
	subgroupSizeControl  = true
	computeFullSubgroups = true

VkPhysicalDeviceTextureCompressionASTCHDRFeaturesEXT:
-----------------------------------------------------
	textureCompressionASTC_HDR = true

VkPhysicalDeviceTimelineSemaphoreFeaturesKHR:
---------------------------------------------
	timelineSemaphore = true

VkPhysicalDeviceTransformFeedbackFeaturesEXT:
---------------------------------------------
	transformFeedback = true
	geometryStreams   = false

VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR:
-------------------------------------------------------
	uniformBufferStandardLayout = true

VkPhysicalDeviceVulkanMemoryModelFeaturesKHR:
---------------------------------------------
	vulkanMemoryModel                             = true
	vulkanMemoryModelDeviceScope                  = true
	vulkanMemoryModelAvailabilityVisibilityChains = true
```

**Android x86_64 emulator:**
```
==========
VULKANINFO
==========

Vulkan Instance Version: 1.3.336


Instance Extensions: count = 11
===============================
	VK_EXT_debug_report                    : extension revision 10
	VK_EXT_swapchain_colorspace            : extension revision 4
	VK_GOOGLE_surfaceless_query            : extension revision 1
	VK_KHR_android_surface                 : extension revision 6
	VK_KHR_external_fence_capabilities     : extension revision 1
	VK_KHR_external_memory_capabilities    : extension revision 1
	VK_KHR_external_semaphore_capabilities : extension revision 1
	VK_KHR_get_physical_device_properties2 : extension revision 2
	VK_KHR_get_surface_capabilities2       : extension revision 1
	VK_KHR_surface                         : extension revision 25
	VK_KHR_surface_protected_capabilities  : extension revision 1

Layers:
=======
Device Properties and Extensions:
=================================
GPU0:
VkPhysicalDeviceProperties:
---------------------------
	apiVersion        = 1.3.0 (4206592)
	driverVersion     = 25.0.7 (104857607)
	vendorID          = 0x8086
	deviceID          = 0x7d55
	deviceType        = PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU
	deviceName        = Intel(R) Arc(tm) Graphics (MTL)
	pipelineCacheUUID = 033d3ad1-6387-12cc-611b-20e98207afda

VkPhysicalDeviceLimits:
-----------------------
	maxImageDimension1D                             = 16384
	maxImageDimension2D                             = 16384
	maxImageDimension3D                             = 2048
	maxImageDimensionCube                           = 16384
	maxImageArrayLayers                             = 2048
	maxTexelBufferElements                          = 134217728
	maxUniformBufferRange                           = 1073741824
	maxStorageBufferRange                           = 4294967295
	maxPushConstantsSize                            = 256
	maxMemoryAllocationCount                        = 4294967295
	maxSamplerAllocationCount                       = 65536
	bufferImageGranularity                          = 0x00000001
	sparseAddressSpaceSize                          = 0xfff00000000
	maxBoundDescriptorSets                          = 8
	maxPerStageDescriptorSamplers                   = 67108864
	maxPerStageDescriptorUniformBuffers             = 33554432
	maxPerStageDescriptorStorageBuffers             = 33554432
	maxPerStageDescriptorSampledImages              = 33554432
	maxPerStageDescriptorStorageImages              = 33554432
	maxPerStageDescriptorInputAttachments           = 64
	maxPerStageResources                            = 33554432
	maxDescriptorSetSamplers                        = 67108864
	maxDescriptorSetUniformBuffers                  = 33554432
	maxDescriptorSetUniformBuffersDynamic           = 8
	maxDescriptorSetStorageBuffers                  = 33554432
	maxDescriptorSetStorageBuffersDynamic           = 8
	maxDescriptorSetSampledImages                   = 33554432
	maxDescriptorSetStorageImages                   = 33554432
	maxDescriptorSetInputAttachments                = 256
	maxVertexInputAttributes                        = 29
	maxVertexInputBindings                          = 31
	maxVertexInputAttributeOffset                   = 2047
	maxVertexInputBindingStride                     = 4095
	maxVertexOutputComponents                       = 128
	maxTessellationGenerationLevel                  = 64
	maxTessellationPatchSize                        = 32
	maxTessellationControlPerVertexInputComponents  = 128
	maxTessellationControlPerVertexOutputComponents = 128
	maxTessellationControlPerPatchOutputComponents  = 128
	maxTessellationControlTotalOutputComponents     = 2048
	maxTessellationEvaluationInputComponents        = 128
	maxTessellationEvaluationOutputComponents       = 128
	maxGeometryShaderInvocations                    = 32
	maxGeometryInputComponents                      = 128
	maxGeometryOutputComponents                     = 128
	maxGeometryOutputVertices                       = 256
	maxGeometryTotalOutputComponents                = 1024
	maxFragmentInputComponents                      = 116
	maxFragmentOutputAttachments                    = 8
	maxFragmentDualSrcAttachments                   = 1
	maxFragmentCombinedOutputResources              = 67108872
	maxComputeSharedMemorySize                      = 65536
	maxComputeWorkGroupCount: count = 3
		65535
		65535
		65535
	maxComputeWorkGroupInvocations                  = 1024
	maxComputeWorkGroupSize: count = 3
		1024
		1024
		1024
	subPixelPrecisionBits                           = 8
	subTexelPrecisionBits                           = 8
	mipmapPrecisionBits                             = 8
	maxDrawIndexedIndexValue                        = 4294967295
	maxDrawIndirectCount                            = 4294967295
	maxSamplerLodBias                               = 16
	maxSamplerAnisotropy                            = 16
	maxViewports                                    = 16
	maxViewportDimensions: count = 2
		16384
		16384
	viewportBoundsRange: count = 2
		-32768
		32767
	viewportSubPixelBits                            = 13
	minMemoryMapAlignment                           = 4096
	minTexelBufferOffsetAlignment                   = 0x00000010
	minUniformBufferOffsetAlignment                 = 0x00000040
	minStorageBufferOffsetAlignment                 = 0x00000004
	minTexelOffset                                  = -8
	maxTexelOffset                                  = 7
	minTexelGatherOffset                            = -32
	maxTexelGatherOffset                            = 31
	minInterpolationOffset                          = -0.5
	maxInterpolationOffset                          = 0.4375
	subPixelInterpolationOffsetBits                 = 4
	maxFramebufferWidth                             = 16384
	maxFramebufferHeight                            = 16384
	maxFramebufferLayers                            = 2048
	framebufferColorSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferDepthSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferStencilSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	framebufferNoAttachmentsSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	maxColorAttachments                             = 8
	sampledImageColorSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageIntegerSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageDepthSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	sampledImageStencilSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT
	storageImageSampleCounts: count = 1
		SAMPLE_COUNT_1_BIT
	maxSampleMaskWords                              = 1
	timestampComputeAndGraphics                     = true
	timestampPeriod                                 = 52.0833
	maxClipDistances                                = 8
	maxCullDistances                                = 8
	maxCombinedClipAndCullDistances                 = 8
	discreteQueuePriorities                         = 2
	pointSizeRange: count = 2
		0.125
		255.875
	lineWidthRange: count = 2
		0
		8
	pointSizeGranularity                            = 0.125
	lineWidthGranularity                            = 0.0078125
	strictLines                                     = false
	standardSampleLocations                         = true
	optimalBufferCopyOffsetAlignment                = 0x00000080
	optimalBufferCopyRowPitchAlignment              = 0x00000080
	nonCoherentAtomSize                             = 0x00000040

VkPhysicalDeviceSparseProperties:
---------------------------------
	residencyStandard2DBlockShape            = true
	residencyStandard2DMultisampleBlockShape = false
	residencyStandard3DBlockShape            = true
	residencyAlignedMipSize                  = false
	residencyNonResidentStrict               = true

VkPhysicalDeviceCustomBorderColorPropertiesEXT:
-----------------------------------------------
	maxCustomBorderColorSamplers = 4096

VkPhysicalDeviceLineRasterizationPropertiesEXT:
-----------------------------------------------
	lineSubPixelPrecisionBits = 4

VkPhysicalDeviceProvokingVertexPropertiesEXT:
---------------------------------------------
	provokingVertexModePerPipeline                       = true
	transformFeedbackPreservesTriangleFanProvokingVertex = false

VkPhysicalDeviceTransformFeedbackPropertiesEXT:
-----------------------------------------------
	maxTransformFeedbackStreams                = 4
	maxTransformFeedbackBuffers                = 4
	maxTransformFeedbackBufferSize             = 0x100000000
	maxTransformFeedbackStreamDataSize         = 512
	maxTransformFeedbackBufferDataSize         = 512
	maxTransformFeedbackBufferDataStride       = 2048
	transformFeedbackQueries                   = true
	transformFeedbackStreamsLinesTriangles     = false
	transformFeedbackRasterizationStreamSelect = false
	transformFeedbackDraw                      = true

VkPhysicalDeviceVulkan11Properties:
-----------------------------------
	deviceUUID                        = 8680557d-0800-0000-0002-000000000000
	driverUUID                        = 380ec810-5d64-cbbd-0034-d8c5a796bd6c
	deviceNodeMask                    = 0
	deviceLUIDValid                   = false
	subgroupSize                      = 32
	subgroupSupportedStages: count = 14
		SHADER_STAGE_VERTEX_BIT
		SHADER_STAGE_TESSELLATION_CONTROL_BIT
		SHADER_STAGE_TESSELLATION_EVALUATION_BIT
		SHADER_STAGE_GEOMETRY_BIT
		SHADER_STAGE_FRAGMENT_BIT
		SHADER_STAGE_COMPUTE_BIT
		SHADER_STAGE_RAYGEN_BIT_KHR
		SHADER_STAGE_ANY_HIT_BIT_KHR
		SHADER_STAGE_CLOSEST_HIT_BIT_KHR
		SHADER_STAGE_MISS_BIT_KHR
		SHADER_STAGE_INTERSECTION_BIT_KHR
		SHADER_STAGE_CALLABLE_BIT_KHR
		SHADER_STAGE_TASK_BIT_EXT
		SHADER_STAGE_MESH_BIT_EXT
	subgroupSupportedOperations: count = 10
		SUBGROUP_FEATURE_BASIC_BIT
		SUBGROUP_FEATURE_VOTE_BIT
		SUBGROUP_FEATURE_ARITHMETIC_BIT
		SUBGROUP_FEATURE_BALLOT_BIT
		SUBGROUP_FEATURE_SHUFFLE_BIT
		SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT
		SUBGROUP_FEATURE_CLUSTERED_BIT
		SUBGROUP_FEATURE_QUAD_BIT
		SUBGROUP_FEATURE_ROTATE_BIT
		SUBGROUP_FEATURE_ROTATE_CLUSTERED_BIT
	subgroupQuadOperationsInAllStages = true
	pointClippingBehavior             = POINT_CLIPPING_BEHAVIOR_USER_CLIP_PLANES_ONLY
	maxMultiviewViewCount             = 16
	maxMultiviewInstanceIndex         = 268435455
	protectedNoFault                  = false
	maxPerSetDescriptors              = 1024
	maxMemoryAllocationSize           = 0x3e1701000

VkPhysicalDeviceVulkan12Properties:
-----------------------------------
	driverID                                             = DRIVER_ID_INTEL_OPEN_SOURCE_MESA
	driverName                                           = Intel open-source Mesa driver
	driverInfo                                           = Mesa 25.0.7-2
	conformanceVersion:
		major    = 1
		minor    = 4
		subminor = 0
		patch    = 0
	denormBehaviorIndependence                           = SHADER_FLOAT_CONTROLS_INDEPENDENCE_ALL
	roundingModeIndependence                             = SHADER_FLOAT_CONTROLS_INDEPENDENCE_NONE
	shaderSignedZeroInfNanPreserveFloat16                = true
	shaderSignedZeroInfNanPreserveFloat32                = true
	shaderSignedZeroInfNanPreserveFloat64                = true
	shaderDenormPreserveFloat16                          = true
	shaderDenormPreserveFloat32                          = true
	shaderDenormPreserveFloat64                          = true
	shaderDenormFlushToZeroFloat16                       = false
	shaderDenormFlushToZeroFloat32                       = true
	shaderDenormFlushToZeroFloat64                       = true
	shaderRoundingModeRTEFloat16                         = true
	shaderRoundingModeRTEFloat32                         = true
	shaderRoundingModeRTEFloat64                         = true
	shaderRoundingModeRTZFloat16                         = true
	shaderRoundingModeRTZFloat32                         = true
	shaderRoundingModeRTZFloat64                         = true
	maxUpdateAfterBindDescriptorsInAllPools              = 33554432
	shaderUniformBufferArrayNonUniformIndexingNative     = false
	shaderSampledImageArrayNonUniformIndexingNative      = false
	shaderStorageBufferArrayNonUniformIndexingNative     = true
	shaderStorageImageArrayNonUniformIndexingNative      = false
	shaderInputAttachmentArrayNonUniformIndexingNative   = false
	robustBufferAccessUpdateAfterBind                    = true
	quadDivergentImplicitLod                             = false
	maxPerStageDescriptorUpdateAfterBindSamplers         = 67108864
	maxPerStageDescriptorUpdateAfterBindUniformBuffers   = 33554432
	maxPerStageDescriptorUpdateAfterBindStorageBuffers   = 33554432
	maxPerStageDescriptorUpdateAfterBindSampledImages    = 33554432
	maxPerStageDescriptorUpdateAfterBindStorageImages    = 33554432
	maxPerStageDescriptorUpdateAfterBindInputAttachments = 64
	maxPerStageUpdateAfterBindResources                  = 33554432
	maxDescriptorSetUpdateAfterBindSamplers              = 67108864
	maxDescriptorSetUpdateAfterBindUniformBuffers        = 33554432
	maxDescriptorSetUpdateAfterBindUniformBuffersDynamic = 8
	maxDescriptorSetUpdateAfterBindStorageBuffers        = 33554432
	maxDescriptorSetUpdateAfterBindStorageBuffersDynamic = 8
	maxDescriptorSetUpdateAfterBindSampledImages         = 33554432
	maxDescriptorSetUpdateAfterBindStorageImages         = 33554432
	maxDescriptorSetUpdateAfterBindInputAttachments      = 256
	supportedDepthResolveModes: count = 4
		RESOLVE_MODE_SAMPLE_ZERO_BIT
		RESOLVE_MODE_AVERAGE_BIT
		RESOLVE_MODE_MIN_BIT
		RESOLVE_MODE_MAX_BIT
	supportedStencilResolveModes: count = 3
		RESOLVE_MODE_SAMPLE_ZERO_BIT
		RESOLVE_MODE_MIN_BIT
		RESOLVE_MODE_MAX_BIT
	independentResolveNone                               = true
	independentResolve                                   = true
	filterMinmaxSingleComponentFormats                   = true
	filterMinmaxImageComponentMapping                    = true
	maxTimelineSemaphoreValueDifference                  = 18446744073709551615
	framebufferIntegerColorSampleCounts: count = 5
		SAMPLE_COUNT_1_BIT
		SAMPLE_COUNT_2_BIT
		SAMPLE_COUNT_4_BIT
		SAMPLE_COUNT_8_BIT
		SAMPLE_COUNT_16_BIT

VkPhysicalDeviceVulkan13Properties:
-----------------------------------
	minSubgroupSize                                                               = 0
	maxSubgroupSize                                                               = 0
	maxComputeWorkgroupSubgroups                                                  = 0
	requiredSubgroupSizeStages:
		None
	maxInlineUniformBlockSize                                                     = 0
	maxPerStageDescriptorInlineUniformBlocks                                      = 0
	maxPerStageDescriptorUpdateAfterBindInlineUniformBlocks                       = 0
	maxDescriptorSetInlineUniformBlocks                                           = 0
	maxDescriptorSetUpdateAfterBindInlineUniformBlocks                            = 0
	maxInlineUniformTotalSize                                                     = 0
	integerDotProduct8BitUnsignedAccelerated                                      = false
	integerDotProduct8BitSignedAccelerated                                        = false
	integerDotProduct8BitMixedSignednessAccelerated                               = false
	integerDotProduct4x8BitPackedUnsignedAccelerated                              = false
	integerDotProduct4x8BitPackedSignedAccelerated                                = false
	integerDotProduct4x8BitPackedMixedSignednessAccelerated                       = false
	integerDotProduct16BitUnsignedAccelerated                                     = false
	integerDotProduct16BitSignedAccelerated                                       = false
	integerDotProduct16BitMixedSignednessAccelerated                              = false
	integerDotProduct32BitUnsignedAccelerated                                     = false
	integerDotProduct32BitSignedAccelerated                                       = false
	integerDotProduct32BitMixedSignednessAccelerated                              = false
	integerDotProduct64BitUnsignedAccelerated                                     = false
	integerDotProduct64BitSignedAccelerated                                       = false
	integerDotProduct64BitMixedSignednessAccelerated                              = false
	integerDotProductAccumulatingSaturating8BitUnsignedAccelerated                = false
	integerDotProductAccumulatingSaturating8BitSignedAccelerated                  = false
	integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated         = false
	integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated        = false
	integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated          = false
	integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated = false
	integerDotProductAccumulatingSaturating16BitUnsignedAccelerated               = false
	integerDotProductAccumulatingSaturating16BitSignedAccelerated                 = false
	integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated        = false
	integerDotProductAccumulatingSaturating32BitUnsignedAccelerated               = false
	integerDotProductAccumulatingSaturating32BitSignedAccelerated                 = false
	integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated        = false
	integerDotProductAccumulatingSaturating64BitUnsignedAccelerated               = false
	integerDotProductAccumulatingSaturating64BitSignedAccelerated                 = false
	integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated        = false
	storageTexelBufferOffsetAlignmentBytes                                        = 0x00000000
	storageTexelBufferOffsetSingleTexelAlignment                                  = false
	uniformTexelBufferOffsetAlignmentBytes                                        = 0x00000000
	uniformTexelBufferOffsetSingleTexelAlignment                                  = false
	maxBufferSize                                                                 = 0x00000000

Device Extensions: count = 34
	VK_ANDROID_external_memory_android_hardware_buffer : extension revision 7
	VK_EXT_custom_border_color                         : extension revision 12
	VK_EXT_image_robustness                            : extension revision 1
	VK_EXT_index_type_uint8                            : extension revision 1
	VK_EXT_line_rasterization                          : extension revision 1
	VK_EXT_load_store_op_none                          : extension revision 1
	VK_EXT_primitive_topology_list_restart             : extension revision 1
	VK_EXT_provoking_vertex                            : extension revision 1
	VK_EXT_queue_family_foreign                        : extension revision 1
	VK_EXT_shader_stencil_export                       : extension revision 1
	VK_EXT_subgroup_size_control                       : extension revision 2
	VK_EXT_transform_feedback                          : extension revision 1
	VK_GOOGLE_display_timing                           : extension revision 1
	VK_KHR_bind_memory2                                : extension revision 1
	VK_KHR_buffer_device_address                       : extension revision 1
	VK_KHR_dedicated_allocation                        : extension revision 3
	VK_KHR_external_fence                              : extension revision 1
	VK_KHR_external_fence_fd                           : extension revision 1
	VK_KHR_external_memory                             : extension revision 1
	VK_KHR_external_semaphore                          : extension revision 1
	VK_KHR_external_semaphore_fd                       : extension revision 1
	VK_KHR_get_memory_requirements2                    : extension revision 1
	VK_KHR_image_format_list                           : extension revision 1
	VK_KHR_incremental_present                         : extension revision 2
	VK_KHR_maintenance1                                : extension revision 2
	VK_KHR_maintenance2                                : extension revision 1
	VK_KHR_maintenance3                                : extension revision 1
	VK_KHR_pipeline_executable_properties              : extension revision 1
	VK_KHR_sampler_ycbcr_conversion                    : extension revision 14
	VK_KHR_shader_float16_int8                         : extension revision 1
	VK_KHR_shader_subgroup_extended_types              : extension revision 1
	VK_KHR_shader_terminate_invocation                 : extension revision 1
	VK_KHR_swapchain                                   : extension revision 68
	VK_KHR_vulkan_memory_model                         : extension revision 3

VkQueueFamilyProperties:
========================
	queueProperties[0]:
	-------------------
		minImageTransferGranularity = (1,1,1)
		queueCount                  = 1
		queueFlags                  = QUEUE_GRAPHICS_BIT | QUEUE_COMPUTE_BIT | QUEUE_TRANSFER_BIT | QUEUE_SPARSE_BINDING_BIT | QUEUE_PROTECTED_BIT
		timestampValidBits          = 36
		present support             = false

VkPhysicalDeviceMemoryProperties:
=================================
memoryHeaps: count = 2
	memoryHeaps[0]:
		size   = 2147483648 (0x80000000) (2.00 GiB)
		flags: count = 1
			MEMORY_HEAP_DEVICE_LOCAL_BIT
	memoryHeaps[1]:
		size   = 536870912 (0x20000000) (512.00 MiB)
		flags:
			None
memoryTypes: count = 9
	memoryTypes[0]:
		heapIndex     = 0
		propertyFlags = 0x0001: count = 1
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse)
	memoryTypes[1]:
		heapIndex     = 0
		propertyFlags = 0x0001: count = 1
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse)
	memoryTypes[2]:
		heapIndex     = 0
		propertyFlags = 0x0021: count = 2
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
			MEMORY_PROPERTY_PROTECTED_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				None
			IMAGE_TILING_LINEAR:
				None
	memoryTypes[3]:
		heapIndex     = 0
		propertyFlags = 0x0001: count = 1
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				None
			IMAGE_TILING_LINEAR:
				None
	memoryTypes[4]:
		heapIndex     = 0
		propertyFlags = 0x0001: count = 1
			MEMORY_PROPERTY_DEVICE_LOCAL_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				None
			IMAGE_TILING_LINEAR:
				None
	memoryTypes[5]:
		heapIndex     = 1
		propertyFlags = 0x0006: count = 2
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_COHERENT_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse)
	memoryTypes[6]:
		heapIndex     = 1
		propertyFlags = 0x000a: count = 2
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_CACHED_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				color images
				FORMAT_D16_UNORM
				FORMAT_X8_D24_UNORM_PACK32
				FORMAT_D32_SFLOAT
				FORMAT_S8_UINT
				FORMAT_D24_UNORM_S8_UINT
				FORMAT_D32_SFLOAT_S8_UINT
				(non-sparse)
			IMAGE_TILING_LINEAR:
				color images
				(non-sparse)
	memoryTypes[7]:
		heapIndex     = 1
		propertyFlags = 0x0006: count = 2
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_COHERENT_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				None
			IMAGE_TILING_LINEAR:
				None
	memoryTypes[8]:
		heapIndex     = 1
		propertyFlags = 0x000a: count = 2
			MEMORY_PROPERTY_HOST_VISIBLE_BIT
			MEMORY_PROPERTY_HOST_CACHED_BIT
		usable for:
			IMAGE_TILING_OPTIMAL:
				None
			IMAGE_TILING_LINEAR:
				None

VkPhysicalDeviceFeatures:
=========================
	robustBufferAccess                      = true
	fullDrawIndexUint32                     = true
	imageCubeArray                          = true
	independentBlend                        = true
	geometryShader                          = true
	tessellationShader                      = true
	sampleRateShading                       = true
	dualSrcBlend                            = true
	logicOp                                 = true
	multiDrawIndirect                       = true
	drawIndirectFirstInstance               = true
	depthClamp                              = true
	depthBiasClamp                          = true
	fillModeNonSolid                        = true
	depthBounds                             = true
	wideLines                               = true
	largePoints                             = true
	alphaToOne                              = true
	multiViewport                           = true
	samplerAnisotropy                       = true
	textureCompressionETC2                  = true
	textureCompressionASTC_LDR              = true
	textureCompressionBC                    = true
	occlusionQueryPrecise                   = true
	pipelineStatisticsQuery                 = true
	vertexPipelineStoresAndAtomics          = true
	fragmentStoresAndAtomics                = true
	shaderTessellationAndGeometryPointSize  = true
	shaderImageGatherExtended               = true
	shaderStorageImageExtendedFormats       = true
	shaderStorageImageMultisample           = false
	shaderStorageImageReadWithoutFormat     = true
	shaderStorageImageWriteWithoutFormat    = true
	shaderUniformBufferArrayDynamicIndexing = true
	shaderSampledImageArrayDynamicIndexing  = true
	shaderStorageBufferArrayDynamicIndexing = true
	shaderStorageImageArrayDynamicIndexing  = true
	shaderClipDistance                      = true
	shaderCullDistance                      = true
	shaderFloat64                           = true
	shaderInt64                             = true
	shaderInt16                             = true
	shaderResourceResidency                 = true
	shaderResourceMinLod                    = true
	sparseBinding                           = false
	sparseResidencyBuffer                   = false
	sparseResidencyImage2D                  = false
	sparseResidencyImage3D                  = false
	sparseResidency2Samples                 = false
	sparseResidency4Samples                 = false
	sparseResidency8Samples                 = false
	sparseResidency16Samples                = false
	sparseResidencyAliased                  = false
	variableMultisampleRate                 = true
	inheritedQueries                        = true

VkPhysicalDeviceCustomBorderColorFeaturesEXT:
---------------------------------------------
	customBorderColors             = true
	customBorderColorWithoutFormat = true

VkPhysicalDeviceIndexTypeUint8FeaturesEXT:
------------------------------------------
	indexTypeUint8 = true

VkPhysicalDeviceLineRasterizationFeaturesEXT:
---------------------------------------------
	rectangularLines         = true
	bresenhamLines           = true
	smoothLines              = false
	stippledRectangularLines = false
	stippledBresenhamLines   = true
	stippledSmoothLines      = false

VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR:
--------------------------------------------------------
	pipelineExecutableInfo = true

VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT:
--------------------------------------------------------
	primitiveTopologyListRestart      = true
	primitiveTopologyPatchListRestart = true

VkPhysicalDeviceProvokingVertexFeaturesEXT:
-------------------------------------------
	provokingVertexLast                       = true
	transformFeedbackPreservesProvokingVertex = true

VkPhysicalDeviceTransformFeedbackFeaturesEXT:
---------------------------------------------
	transformFeedback = true
	geometryStreams   = true

VkPhysicalDeviceVulkan11Features:
---------------------------------
	storageBuffer16BitAccess           = true
	uniformAndStorageBuffer16BitAccess = true
	storagePushConstant16              = true
	storageInputOutput16               = false
	multiview                          = true
	multiviewGeometryShader            = true
	multiviewTessellationShader        = true
	variablePointersStorageBuffer      = true
	variablePointers                   = true
	protectedMemory                    = false
	samplerYcbcrConversion             = true
	shaderDrawParameters               = true

VkPhysicalDeviceVulkan12Features:
---------------------------------
	samplerMirrorClampToEdge                           = true
	drawIndirectCount                                  = true
	storageBuffer8BitAccess                            = true
	uniformAndStorageBuffer8BitAccess                  = true
	storagePushConstant8                               = true
	shaderBufferInt64Atomics                           = true
	shaderSharedInt64Atomics                           = false
	shaderFloat16                                      = true
	shaderInt8                                         = true
	descriptorIndexing                                 = true
	shaderInputAttachmentArrayDynamicIndexing          = false
	shaderUniformTexelBufferArrayDynamicIndexing       = true
	shaderStorageTexelBufferArrayDynamicIndexing       = true
	shaderUniformBufferArrayNonUniformIndexing         = true
	shaderSampledImageArrayNonUniformIndexing          = true
	shaderStorageBufferArrayNonUniformIndexing         = true
	shaderStorageImageArrayNonUniformIndexing          = true
	shaderInputAttachmentArrayNonUniformIndexing       = false
	shaderUniformTexelBufferArrayNonUniformIndexing    = true
	shaderStorageTexelBufferArrayNonUniformIndexing    = true
	descriptorBindingUniformBufferUpdateAfterBind      = true
	descriptorBindingSampledImageUpdateAfterBind       = true
	descriptorBindingStorageImageUpdateAfterBind       = true
	descriptorBindingStorageBufferUpdateAfterBind      = true
	descriptorBindingUniformTexelBufferUpdateAfterBind = true
	descriptorBindingStorageTexelBufferUpdateAfterBind = true
	descriptorBindingUpdateUnusedWhilePending          = true
	descriptorBindingPartiallyBound                    = true
	descriptorBindingVariableDescriptorCount           = true
	runtimeDescriptorArray                             = true
	samplerFilterMinmax                                = true
	scalarBlockLayout                                  = true
	imagelessFramebuffer                               = true
	uniformBufferStandardLayout                        = true
	shaderSubgroupExtendedTypes                        = true
	separateDepthStencilLayouts                        = true
	hostQueryReset                                     = true
	timelineSemaphore                                  = true
	bufferDeviceAddress                                = true
	bufferDeviceAddressCaptureReplay                   = true
	bufferDeviceAddressMultiDevice                     = false
	vulkanMemoryModel                                  = true
	vulkanMemoryModelDeviceScope                       = true
	vulkanMemoryModelAvailabilityVisibilityChains      = true
	shaderOutputViewportIndex                          = true
	shaderOutputLayer                                  = true
	subgroupBroadcastDynamicId                         = true

VkPhysicalDeviceVulkan13Features:
---------------------------------
	robustImageAccess                                  = false
	inlineUniformBlock                                 = false
	descriptorBindingInlineUniformBlockUpdateAfterBind = false
	pipelineCreationCacheControl                       = false
	privateData                                        = false
	shaderDemoteToHelperInvocation                     = false
	shaderTerminateInvocation                          = false
	subgroupSizeControl                                = false
	computeFullSubgroups                               = false
	synchronization2                                   = false
	textureCompressionASTC_HDR                         = false
	shaderZeroInitializeWorkgroupMemory                = false
	dynamicRendering                                   = false
	shaderIntegerDotProduct                            = false
	maintenance4                                       = false
```

Tested on Linux desktop and Android.