### PR TITLE
Fix: UTF-8 character cut off to two "�" in segment wrapping (max_len)

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6026,6 +6026,19 @@ static inline bool should_split_on_word(const char * txt, bool split_on_word) {
     return txt[0] == ' ';
 }
 
+// Count UTF-8 characters (not bytes) in a string
+static int utf8_len(const char * str) {
+    int count = 0;
+    while (*str) {
+        // Skip continuation bytes (10xxxxxx)
+        if ((*str & 0xC0) != 0x80) {
+            count++;
+        }
+        str++;
+    }
+    return count;
+}
+
 static void whisper_exp_compute_token_level_timestamps_dtw(
             struct whisper_context * ctx,
               struct whisper_state * state,
@@ -6054,7 +6067,7 @@ static int whisper_wrap_segment(struct whisper_context & ctx, struct whisper_sta
         }
 
         const auto txt = whisper_token_to_str(&ctx, token.id);
-        const int cur = strlen(txt);
+        const int cur = utf8_len(txt);  // Use UTF-8 character count instead of byte count
 
         if (acc + cur > max_len && i > 0 && should_split_on_word(txt, split_on_word)) {
             state.result_all.back().text = std::move(text);


### PR DESCRIPTION
## Description
Fixes incorrect segment splitting when using `max_len` parameter with multi-byte UTF-8 characters (e.g., Chinese, Japanese, Arabic).

## Problem
The current implementation in `whisper_wrap_segment()` uses `strlen()` to count bytes, not UTF-8 characters. When splitting segments at `max_len`, this can break multi-byte UTF-8 characters, resulting in invalid sequences displayed as `�` (U+FFFD replacement character).

### Example (Chinese text)
**Before fix:**
```json
{"Text": "这个时候面试官会给应聘者一定的时间,由应�"},
{"Text": "�者面试结束之后,面试人立即整理记录,根据求"}
```
**After fix:**
```
{"Text": "这个时候面试官会给应聘者一定的时间,由应聘"},
{"Text": "者面试结束之后,面试人立即整理记录,根据求"}
```

## In Addition
This does change the meaning of the "max_len" parameter.  
And to be honest, I just find out the problem, code modification is Claude's recommendation and I tested it.