### PR TITLE
stream: fix segfault when arg value missing

### DIFF
--- a/examples/bench/bench.cpp
+++ b/examples/bench/bench.cpp
@@ -18,6 +18,15 @@ struct whisper_params {
 
 void whisper_print_usage(int argc, char ** argv, const whisper_params & params);
 
+static const char * get_next_arg(int & i, int argc, char ** argv, const char * flag, whisper_params & params) {
+    if (i + 1 < argc) {
+        return argv[++i];
+    }
+    fprintf(stderr, "error: %s requires an argument\n", flag);
+    whisper_print_usage(argc, argv, params);
+    exit(1);
+}
+
 static bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -26,9 +35,9 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
             whisper_print_usage(argc, argv, params);
             exit(0);
         }
-        else if (arg == "-t"     || arg == "--threads")       { params.n_threads  = std::stoi(argv[++i]); }
-        else if (arg == "-m"     || arg == "--model")         { params.model      = argv[++i]; }
-        else if (arg == "-w"     || arg == "--what")          { params.what       = atoi(argv[++i]); }
+        else if (arg == "-t"     || arg == "--threads")       { params.n_threads  = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-m"     || arg == "--model")         { params.model      = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-w"     || arg == "--what")          { params.what       = atoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
         else if (arg == "-ng"    || arg == "--no-gpu")        { params.use_gpu    = false; }
         else if (arg == "-fa"    || arg == "--flash-attn")    { params.flash_attn = true; }
         else if (arg == "-nfa"   || arg == "--no-flash-attn") { params.flash_attn = false; }

--- a/examples/command/command.cpp
+++ b/examples/command/command.cpp
@@ -58,6 +58,15 @@ struct whisper_params {
 
 void whisper_print_usage(int argc, char ** argv, const whisper_params & params);
 
+static const char * get_next_arg(int & i, int argc, char ** argv, const char * flag, whisper_params & params) {
+    if (i + 1 < argc) {
+        return argv[++i];
+    }
+    fprintf(stderr, "error: %s requires an argument\n", flag);
+    whisper_print_usage(argc, argv, params);
+    exit(1);
+}
+
 static bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -66,29 +75,29 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
             whisper_print_usage(argc, argv, params);
             exit(0);
         }
-        else if (arg == "-t"     || arg == "--threads")       { params.n_threads     = std::stoi(argv[++i]); }
-        else if (arg == "-pms"   || arg == "--prompt-ms")     { params.prompt_ms     = std::stoi(argv[++i]); }
-        else if (arg == "-cms"   || arg == "--command-ms")    { params.command_ms    = std::stoi(argv[++i]); }
-        else if (arg == "-c"     || arg == "--capture")       { params.capture_id    = std::stoi(argv[++i]); }
-        else if (arg == "-mt"    || arg == "--max-tokens")    { params.max_tokens    = std::stoi(argv[++i]); }
-        else if (arg == "-ac"    || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(argv[++i]); }
-        else if (arg == "-vth"   || arg == "--vad-thold")     { params.vad_thold     = std::stof(argv[++i]); }
-        else if (arg == "-fth"   || arg == "--freq-thold")    { params.freq_thold    = std::stof(argv[++i]); }
+        else if (arg == "-t"     || arg == "--threads")       { params.n_threads     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-pms"   || arg == "--prompt-ms")     { params.prompt_ms     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-cms"   || arg == "--command-ms")    { params.command_ms    = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-c"     || arg == "--capture")       { params.capture_id    = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-mt"    || arg == "--max-tokens")    { params.max_tokens    = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-ac"    || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-vth"   || arg == "--vad-thold")     { params.vad_thold     = std::stof(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-fth"   || arg == "--freq-thold")    { params.freq_thold    = std::stof(get_next_arg(i, argc, argv, arg.c_str(), params)); }
         else if (arg == "-tr"    || arg == "--translate")     { params.translate     = true; }
         else if (arg == "-ps"    || arg == "--print-special") { params.print_special = true; }
         else if (arg == "-pe"    || arg == "--print-energy")  { params.print_energy  = true; }
         else if (arg == "-ng"    || arg == "--no-gpu")        { params.use_gpu       = false; }
         else if (arg == "-fa"    || arg == "--flash-attn")    { params.flash_attn    = true; }
         else if (arg == "-nfa"   || arg == "--no-flash-attn") { params.flash_attn    = false; }
-        else if (arg == "-l"     || arg == "--language")      { params.language      = argv[++i]; }
-        else if (arg == "-m"     || arg == "--model")         { params.model         = argv[++i]; }
-        else if (arg == "-f"     || arg == "--file")          { params.fname_out     = argv[++i]; }
-        else if (arg == "-cmd"   || arg == "--commands")      { params.commands      = argv[++i]; }
-        else if (arg == "-p"     || arg == "--prompt")        { params.prompt        = argv[++i]; }
-        else if (arg == "-ctx"   || arg == "--context")       { params.context       = argv[++i]; }
-        else if (                   arg == "--grammar")       { params.grammar       = argv[++i]; }
-        else if (                   arg == "--grammar-penalty") { params.grammar_penalty = std::stof(argv[++i]); }
-        else if (                   arg == "--suppress-regex") { params.suppress_regex = argv[++i]; }
+        else if (arg == "-l"     || arg == "--language")      { params.language      = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-m"     || arg == "--model")         { params.model         = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-f"     || arg == "--file")          { params.fname_out     = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-cmd"   || arg == "--commands")      { params.commands      = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-p"     || arg == "--prompt")        { params.prompt        = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-ctx"   || arg == "--context")       { params.context       = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (                   arg == "--grammar")       { params.grammar       = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (                   arg == "--grammar-penalty") { params.grammar_penalty = std::stof(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (                   arg == "--suppress-regex") { params.suppress_regex = get_next_arg(i, argc, argv, arg.c_str(), params); }
         else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             whisper_print_usage(argc, argv, params);

--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -197,6 +197,14 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "\n");
 }
 
+static const char * get_next_arg(int & i, int argc, char ** argv, const char * flag) {
+    if (i + 1 < argc) {
+        return argv[++i];
+    }
+    fprintf(stderr, "error: %s requires an argument\n", flag);
+    exit(1);
+}
+
 bool whisper_params_parse(int argc, char ** argv, whisper_params & params, server_params & sparams) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -205,62 +213,62 @@ bool whisper_params_parse(int argc, char ** argv, whisper_params & params, serve
             whisper_print_usage(argc, argv, params, sparams);
             exit(0);
         }
-        else if (arg == "-t"    || arg == "--threads")         { params.n_threads       = std::stoi(argv[++i]); }
-        else if (arg == "-p"    || arg == "--processors")      { params.n_processors    = std::stoi(argv[++i]); }
-        else if (arg == "-ot"   || arg == "--offset-t")        { params.offset_t_ms     = std::stoi(argv[++i]); }
-        else if (arg == "-on"   || arg == "--offset-n")        { params.offset_n        = std::stoi(argv[++i]); }
-        else if (arg == "-d"    || arg == "--duration")        { params.duration_ms     = std::stoi(argv[++i]); }
-        else if (arg == "-mc"   || arg == "--max-context")     { params.max_context     = std::stoi(argv[++i]); }
-        else if (arg == "-ml"   || arg == "--max-len")         { params.max_len         = std::stoi(argv[++i]); }
-        else if (arg == "-bo"   || arg == "--best-of")         { params.best_of         = std::stoi(argv[++i]); }
-        else if (arg == "-bs"   || arg == "--beam-size")       { params.beam_size       = std::stoi(argv[++i]); }
-        else if (arg == "-ac"   || arg == "--audio-ctx")       { params.audio_ctx       = std::stoi(argv[++i]); }
-        else if (arg == "-wt"   || arg == "--word-thold")      { params.word_thold      = std::stof(argv[++i]); }
-        else if (arg == "-et"   || arg == "--entropy-thold")   { params.entropy_thold   = std::stof(argv[++i]); }
-        else if (arg == "-lpt"  || arg == "--logprob-thold")   { params.logprob_thold   = std::stof(argv[++i]); }
+        else if (arg == "-t"    || arg == "--threads")         { params.n_threads       = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-p"    || arg == "--processors")      { params.n_processors    = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-ot"   || arg == "--offset-t")        { params.offset_t_ms     = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-on"   || arg == "--offset-n")        { params.offset_n        = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-d"    || arg == "--duration")        { params.duration_ms     = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-mc"   || arg == "--max-context")     { params.max_context     = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-ml"   || arg == "--max-len")         { params.max_len         = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-bo"   || arg == "--best-of")         { params.best_of         = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-bs"   || arg == "--beam-size")       { params.beam_size       = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-ac"   || arg == "--audio-ctx")       { params.audio_ctx       = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-wt"   || arg == "--word-thold")      { params.word_thold      = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-et"   || arg == "--entropy-thold")   { params.entropy_thold   = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-lpt"  || arg == "--logprob-thold")   { params.logprob_thold   = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
         else if (arg == "-debug"|| arg == "--debug-mode")      { params.debug_mode      = true; }
         else if (arg == "-tr"   || arg == "--translate")       { params.translate       = true; }
         else if (arg == "-di"   || arg == "--diarize")         { params.diarize         = true; }
         else if (arg == "-tdrz" || arg == "--tinydiarize")     { params.tinydiarize     = true; }
         else if (arg == "-sow"  || arg == "--split-on-word")   { params.split_on_word   = true; }
         else if (arg == "-nf"   || arg == "--no-fallback")     { params.no_fallback     = true; }
-        else if (arg == "-fp"   || arg == "--font-path")       { params.font_path       = argv[++i]; }
+        else if (arg == "-fp"   || arg == "--font-path")       { params.font_path       = get_next_arg(i, argc, argv, arg.c_str()); }
         else if (arg == "-ps"   || arg == "--print-special")   { params.print_special   = true; }
         else if (arg == "-pc"   || arg == "--print-colors")    { params.print_colors    = true; }
         else if (arg == "-pr"   || arg == "--print-realtime")  { params.print_realtime  = true; }
         else if (arg == "-pp"   || arg == "--print-progress")  { params.print_progress  = true; }
         else if (arg == "-nt"   || arg == "--no-timestamps")   { params.no_timestamps   = true; }
-        else if (arg == "-l"    || arg == "--language")        { params.language        = argv[++i]; }
+        else if (arg == "-l"    || arg == "--language")        { params.language        = get_next_arg(i, argc, argv, arg.c_str()); }
         else if (arg == "-dl"   || arg == "--detect-language") { params.detect_language = true; }
-        else if (                  arg == "--prompt")          { params.prompt          = argv[++i]; }
-        else if (arg == "-m"    || arg == "--model")           { params.model           = argv[++i]; }
-        else if (arg == "-oved" || arg == "--ov-e-device")     { params.openvino_encode_device = argv[++i]; }
-        else if (arg == "-dtw"  || arg == "--dtw")             { params.dtw             = argv[++i]; }
+        else if (                  arg == "--prompt")          { params.prompt          = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (arg == "-m"    || arg == "--model")           { params.model           = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (arg == "-oved" || arg == "--ov-e-device")     { params.openvino_encode_device = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (arg == "-dtw"  || arg == "--dtw")             { params.dtw             = get_next_arg(i, argc, argv, arg.c_str()); }
         else if (arg == "-ng"   || arg == "--no-gpu")          { params.use_gpu         = false; }
         else if (arg == "-fa"   || arg == "--flash-attn")      { params.flash_attn      = true; }
         else if (arg == "-nfa"  || arg == "--no-flash-attn")   { params.flash_attn      = false; }
         else if (arg == "-sns"  || arg == "--suppress-nst")    { params.suppress_nst    = true; }
-        else if (arg == "-nth"  || arg == "--no-speech-thold") { params.no_speech_thold = std::stof(argv[++i]); }
+        else if (arg == "-nth"  || arg == "--no-speech-thold") { params.no_speech_thold = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
         else if (arg == "-nlp"  || arg == "--no-language-probabilities") { params.no_language_probabilities = true; }
 
         // server params
-        else if (                  arg == "--port")            { sparams.port        = std::stoi(argv[++i]); }
-        else if (                  arg == "--host")            { sparams.hostname    = argv[++i]; }
-        else if (                  arg == "--public")          { sparams.public_path = argv[++i]; }
-        else if (                  arg == "--request-path")    { sparams.request_path = argv[++i]; }
-        else if (                  arg == "--inference-path")  { sparams.inference_path = argv[++i]; }
+        else if (                  arg == "--port")            { sparams.port        = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (                  arg == "--host")            { sparams.hostname    = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (                  arg == "--public")          { sparams.public_path = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (                  arg == "--request-path")    { sparams.request_path = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (                  arg == "--inference-path")  { sparams.inference_path = get_next_arg(i, argc, argv, arg.c_str()); }
         else if (                  arg == "--convert")         { sparams.ffmpeg_converter     = true; }
-        else if (                  arg == "--tmp-dir")         { sparams.tmp_dir     = argv[++i]; }
+        else if (                  arg == "--tmp-dir")         { sparams.tmp_dir     = get_next_arg(i, argc, argv, arg.c_str()); }
 
         // Voice Activity Detection (VAD)
         else if (                  arg == "--vad")                         { params.vad                         = true; }
-        else if (arg == "-vm"   || arg == "--vad-model")                   { params.vad_model                   = argv[++i]; }
-        else if (arg == "-vt"   || arg == "--vad-threshold")               { params.vad_threshold               = std::stof(argv[++i]); }
-        else if (arg == "-vspd" || arg == "--vad-min-speech-duration-ms")  { params.vad_min_speech_duration_ms  = std::stoi(argv[++i]); }
-        else if (arg == "-vsd"  || arg == "--vad-min-silence-duration-ms") { params.vad_min_silence_duration_ms = std::stoi(argv[++i]); }
-        else if (arg == "-vmsd" || arg == "--vad-max-speech-duration-s")   { params.vad_max_speech_duration_s   = std::stof(argv[++i]); }
-        else if (arg == "-vp"   || arg == "--vad-speech-pad-ms")           { params.vad_speech_pad_ms           = std::stoi(argv[++i]); }
-        else if (arg == "-vo"   || arg == "--vad-samples-overlap")         { params.vad_samples_overlap         = std::stof(argv[++i]); }
+        else if (arg == "-vm"   || arg == "--vad-model")                   { params.vad_model                   = get_next_arg(i, argc, argv, arg.c_str()); }
+        else if (arg == "-vt"   || arg == "--vad-threshold")               { params.vad_threshold               = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-vspd" || arg == "--vad-min-speech-duration-ms")  { params.vad_min_speech_duration_ms  = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-vsd"  || arg == "--vad-min-silence-duration-ms") { params.vad_min_silence_duration_ms = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-vmsd" || arg == "--vad-max-speech-duration-s")   { params.vad_max_speech_duration_s   = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-vp"   || arg == "--vad-speech-pad-ms")           { params.vad_speech_pad_ms           = std::stoi(get_next_arg(i, argc, argv, arg.c_str())); }
+        else if (arg == "-vo"   || arg == "--vad-samples-overlap")         { params.vad_samples_overlap         = std::stof(get_next_arg(i, argc, argv, arg.c_str())); }
         else {
             fprintf(stderr, "error: unknown argument: %s\n", arg.c_str());
             whisper_print_usage(argc, argv, params, sparams);

--- a/examples/stream/stream.cpp
+++ b/examples/stream/stream.cpp
@@ -45,6 +45,15 @@ struct whisper_params {
 
 void whisper_print_usage(int argc, char ** argv, const whisper_params & params);
 
+static const char * get_next_arg(int & i, int argc, char ** argv, const char * flag, whisper_params & params) {
+    if (i + 1 < argc) {
+        return argv[++i];
+    }
+    fprintf(stderr, "error: %s requires an argument\n", flag);
+    whisper_print_usage(argc, argv, params);
+    exit(1);
+}
+
 static bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -53,23 +62,23 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
             whisper_print_usage(argc, argv, params);
             exit(0);
         }
-        else if (arg == "-t"    || arg == "--threads")       { params.n_threads     = std::stoi(argv[++i]); }
-        else if (                  arg == "--step")          { params.step_ms       = std::stoi(argv[++i]); }
-        else if (                  arg == "--length")        { params.length_ms     = std::stoi(argv[++i]); }
-        else if (                  arg == "--keep")          { params.keep_ms       = std::stoi(argv[++i]); }
-        else if (arg == "-c"    || arg == "--capture")       { params.capture_id    = std::stoi(argv[++i]); }
-        else if (arg == "-mt"   || arg == "--max-tokens")    { params.max_tokens    = std::stoi(argv[++i]); }
-        else if (arg == "-ac"   || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(argv[++i]); }
-        else if (arg == "-bs"   || arg == "--beam-size")     { params.beam_size     = std::stoi(argv[++i]); }
-        else if (arg == "-vth"  || arg == "--vad-thold")     { params.vad_thold     = std::stof(argv[++i]); }
-        else if (arg == "-fth"  || arg == "--freq-thold")    { params.freq_thold    = std::stof(argv[++i]); }
+        else if (arg == "-t"    || arg == "--threads")       { params.n_threads     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (                  arg == "--step")          { params.step_ms       = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (                  arg == "--length")        { params.length_ms     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (                  arg == "--keep")          { params.keep_ms       = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-c"    || arg == "--capture")       { params.capture_id    = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-mt"   || arg == "--max-tokens")    { params.max_tokens    = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-ac"   || arg == "--audio-ctx")     { params.audio_ctx     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-bs"   || arg == "--beam-size")     { params.beam_size     = std::stoi(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-vth"  || arg == "--vad-thold")     { params.vad_thold     = std::stof(get_next_arg(i, argc, argv, arg.c_str(), params)); }
+        else if (arg == "-fth"  || arg == "--freq-thold")    { params.freq_thold    = std::stof(get_next_arg(i, argc, argv, arg.c_str(), params)); }
         else if (arg == "-tr"   || arg == "--translate")     { params.translate     = true; }
         else if (arg == "-nf"   || arg == "--no-fallback")   { params.no_fallback   = true; }
         else if (arg == "-ps"   || arg == "--print-special") { params.print_special = true; }
         else if (arg == "-kc"   || arg == "--keep-context")  { params.no_context    = false; }
-        else if (arg == "-l"    || arg == "--language")      { params.language      = argv[++i]; }
-        else if (arg == "-m"    || arg == "--model")         { params.model         = argv[++i]; }
-        else if (arg == "-f"    || arg == "--file")          { params.fname_out     = argv[++i]; }
+        else if (arg == "-l"    || arg == "--language")      { params.language      = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-m"    || arg == "--model")         { params.model         = get_next_arg(i, argc, argv, arg.c_str(), params); }
+        else if (arg == "-f"    || arg == "--file")          { params.fname_out     = get_next_arg(i, argc, argv, arg.c_str(), params); }
         else if (arg == "-tdrz" || arg == "--tinydiarize")   { params.tinydiarize   = true; }
         else if (arg == "-sa"   || arg == "--save-audio")    { params.save_audio    = true; }
         else if (arg == "-ng"   || arg == "--no-gpu")        { params.use_gpu       = false; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,3 +110,8 @@ target_compile_definitions(${VAD_TEST} PRIVATE
     SAMPLE_PATH="${PROJECT_SOURCE_DIR}/samples/jfk.wav")
 add_test(NAME ${VAD_TEST} COMMAND ${VAD_TEST})
 set_tests_properties(${VAD_TEST} PROPERTIES LABELS "base;en")
+
+# Test argument parsing (no segfault on missing arg values)
+add_test(NAME test-stream-arg-parsing
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/test-arg-parsing.sh $<TARGET_FILE:whisper-stream>)
+set_tests_properties(test-stream-arg-parsing PROPERTIES LABELS "unit")

--- a/tests/test-arg-parsing.sh
+++ b/tests/test-arg-parsing.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Test that command-line argument parsing handles missing values gracefully
+# (exits with code 1, not segfault 139)
+
+WHISPER_STREAM="${1:-../build/bin/whisper-stream}"
+
+failed=0
+
+test_missing_arg() {
+    local flag=$1
+    local output
+    local exit_code
+
+    output=$("$WHISPER_STREAM" "$flag" 2>&1)
+    exit_code=$?
+
+    if [ $exit_code -eq 1 ]; then
+        echo "PASS: $flag (exit code 1)"
+    elif [ $exit_code -eq 139 ]; then
+        echo "FAIL: $flag caused segfault (exit code 139)"
+        failed=1
+    else
+        echo "FAIL: $flag unexpected exit code $exit_code"
+        failed=1
+    fi
+
+    # Also verify error message mentions the flag
+    if ! echo "$output" | grep -q "requires an argument"; then
+        echo "WARN: $flag did not show expected error message"
+    fi
+}
+
+echo "Testing whisper-stream argument parsing..."
+echo
+
+# Test all flags that require arguments
+test_missing_arg "-l"
+test_missing_arg "-m"
+test_missing_arg "-t"
+test_missing_arg "-f"
+test_missing_arg "-c"
+test_missing_arg "--language"
+test_missing_arg "--model"
+test_missing_arg "--threads"
+
+echo
+if [ $failed -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "Some tests failed!"
+    exit 1
+fi


### PR DESCRIPTION
Add bounds checking for command-line arguments that require values. Previously, flags like -l, -m, -t would segfault if used without providing the required argument value (e.g. as terminal arguments). This now matches the behaviour of examples/common.cpp

Affected: whisper-stream, whisper-server, whisper-bench, whisper-command