### PR TITLE
feat(cli): add word-level LRC output with UTF-8 fix

### DIFF
--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -37,6 +37,7 @@ options:
   -ovtt,     --output-vtt        [false  ] output result in a vtt file
   -osrt,     --output-srt        [false  ] output result in a srt file
   -olrc,     --output-lrc        [false  ] output result in a lrc file
+  -olrcw,    --output-lrc-word   [false  ] output result in a word-level lrc file
   -owts,     --output-words      [false  ] output script for generating karaoke video
   -fp,       --font-path         [/System/Library/Fonts/Supplemental/Courier New Bold.ttf] path to a monospace font for karaoke video
   -ocsv,     --output-csv        [false  ] output result in a CSV file


### PR DESCRIPTION
## Summary

Add new `-olrcw`/`--output-lrc-word` option for word-level LRC output with inline timestamps per token, and fix UTF-8 character handling issues.

### Changes
- Add `output_lrc_word` parameter and CLI option `-olrcw`
- Implement `output_lrc_word()` function with per-token timestamps
- Fix UTF-8 multi-byte character handling by merging continuation bytes
- Enable `token_timestamps` when `output_lrc_word` is set
- Handle diarize speaker prefix without breaking LRC format
- Update README.md with new option

### UTF-8 Fix (addresses #1798)

CJK characters (3 bytes in UTF-8) were being split across tokens with timestamps inserted between bytes:

**Before (broken):**
```
[00:00.50]ã[00:00.52]ª[00:00.54]ã...
```

**After (fixed):**
```
[00:00.50]私[00:00.80]は[00:01.10]歌...
```

The fix detects UTF-8 continuation bytes (`10xxxxxx`) and merges them with the previous token.

### Output Format

```
[by:whisper.cpp]
[00:00.50]私[00:00.80]は[00:01.10]歌[00:01.40]を[00:01.70]歌[00:02.00]います
```

## Test Plan
- [x] Tested with Japanese songs (CJK characters)
- [x] Verified UTF-8 characters are not split
- [x] Verified timestamps are accurate (with DTW)