### PR TITLE
fix(coreml): remove broken --optimize-ane flag from generate script

### DIFF
--- a/models/generate-coreml-model.sh
+++ b/models/generate-coreml-model.sh
@@ -25,7 +25,10 @@ if [ "$mname" = "-h5" ]; then
   echo "$mpath"
   python3 models/convert-h5-to-coreml.py --model-name "$mname" --model-path "$mpath" --encoder-only True
 else
-  python3 models/convert-whisper-to-coreml.py --model "$mname" --encoder-only True --optimize-ane True
+  # Note: --optimize-ane is disabled as it produces models that crash during inference.
+  # The ANE optimization code needs maintenance to work with newer model architectures
+  # and coremltools versions. See convert-whisper-to-coreml.py for details.
+  python3 models/convert-whisper-to-coreml.py --model "$mname" --encoder-only True
 fi
 
 xcrun coremlc compile models/coreml-encoder-"${mname}".mlpackage models/


### PR DESCRIPTION
## Summary

The `generate-coreml-model.sh` script currently passes `--optimize-ane True` to the conversion script, but this flag is explicitly marked as broken:

```python
parser.add_argument("--optimize-ane", type=bool, help="optimize for ANE execution (currently broken)", default=False)
```

## Problem

When `--optimize-ane True` is used, the generated CoreML models:
1. **Load successfully** - whisper.cpp reports `Core ML model loaded`
2. **Crash during inference** - SIGSEGV when processing audio

The ANE optimization code (`WhisperANE` classes) hasn't been maintained to work with:
- Newer model architectures (e.g., large-v3-turbo with 128 mel bins vs 80)
- Recent coremltools versions that generate iOS 18+ specific ops (`Ios18.scaledDotProductAttention`, etc.)

## Solution

Remove the `--optimize-ane True` flag from the shell script, allowing it to use the working default (`False`).

Added a comment explaining why ANE optimization is disabled for future maintainers.

## Testing

Tested on M4 Mac mini with large-v3-turbo model:
- **Before (with --optimize-ane)**: SIGSEGV crash during inference
- **After (without flag)**: Model loads and transcribes correctly with `COREML = 1`

## Related

- Original CoreML PR: #566
- ANE optimization marked broken in code since it was added
- Related issues: #2057, #1021