### PR TITLE
ggml-vulkan: serialize racy vk_instance initialization

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -2561,6 +2561,7 @@ struct vk_instance_t {
     vk_device devices[GGML_VK_MAX_DEVICES];
 };
 
+static std::recursive_mutex vk_instance_init_mutex;
 static bool vk_instance_initialized = false;
 static vk_instance_t vk_instance;
 
@@ -6129,6 +6130,7 @@ static uint32_t ggml_vk_intel_shader_core_count(const vk::PhysicalDevice& vkdev)
 static vk_device ggml_vk_get_device(size_t idx) {
     VK_LOG_DEBUG("ggml_vk_get_device(" << idx << ")");
 
+    std::lock_guard<std::recursive_mutex> lock(vk_instance_init_mutex);
     if (vk_instance.devices[idx] == nullptr) {
         VK_LOG_DEBUG("Initializing new vk_device");
         vk_device device = std::make_shared<vk_device_struct>();
@@ -7318,6 +7320,7 @@ DispatchLoaderDynamic & ggml_vk_default_dispatcher() {
 }
 
 static void ggml_vk_instance_init() {
+    std::lock_guard<std::recursive_mutex> lock(vk_instance_init_mutex);
     if (vk_instance_initialized) {
         return;
     }


### PR DESCRIPTION
When calling whisper_init_from_file_with_params_no_state() from multiple threads with the Vulkan backend enabled, segfaults abound. The problem seems to be that vk_instance initialization is not serialized properly. Introduce a mutex to fix the problem. It needs to be recursive because of the following call chain:
```
  ggml_vk_get_device()
  -> ggml_backend_vk_reg()
  -> ggml_vk_instance_init()
```