### PR TITLE
build: reduce cpu and vulkan docker image size

### DIFF
--- a/.devops/main-vulkan.Dockerfile
+++ b/.devops/main-vulkan.Dockerfile
@@ -5,16 +5,28 @@ RUN apt-get update && \
   apt-get install -y build-essential wget cmake git libvulkan-dev glslc \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-COPY .. .
-RUN make base.en CMAKE_ARGS="-DGGML_VULKAN=1"
+COPY . .
+
+RUN cmake -B build -DGGML_NATIVE=OFF -DGGML_VULKAN=ON -DWHISPER_BUILD_TESTS=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON \
+  && cmake --build build --config Release -j $(nproc)
+
+RUN mkdir -p /app/lib && \
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
 
 FROM ubuntu:24.04 AS runtime
 WORKDIR /app
 
-RUN apt-get update && \
-  apt-get install -y curl ffmpeg libsdl2-dev wget cmake git libvulkan1 mesa-vulkan-drivers \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+RUN apt-get update \
+  && apt-get install -y curl ffmpeg wget libvulkan1 mesa-vulkan-drivers \
+  && apt autoremove -y \
+  && apt clean -y \
+  && rm -rf /tmp/* /var/tmp/* \
+  && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+  && find /var/cache -type f -delete
 
-COPY --from=build /app /app
-ENV PATH=/app/build/bin:$PATH
+COPY --from=build /app/build/bin /app
+COPY --from=build /app/lib /app
+COPY --from=build /app/models /app/models
+
+ENV PATH=/app:$PATH
 ENTRYPOINT [ "bash", "-c" ]

--- a/.devops/main.Dockerfile
+++ b/.devops/main.Dockerfile
@@ -1,20 +1,32 @@
-FROM ubuntu:22.04 AS build
+FROM ubuntu:24.04 AS build
 WORKDIR /app
 
 RUN apt-get update && \
   apt-get install -y build-essential wget cmake git \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-COPY .. .
-RUN make base.en
+COPY . .
 
-FROM ubuntu:22.04 AS runtime
+RUN cmake -B build -DGGML_NATIVE=OFF -DWHISPER_BUILD_TESTS=OFF -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON \
+  && cmake --build build --config Release -j $(nproc)
+
+RUN mkdir -p /app/lib && \
+    find build -name "*.so*" -exec cp -P {} /app/lib \;
+
+FROM ubuntu:24.04 AS runtime
 WORKDIR /app
 
-RUN apt-get update && \
-  apt-get install -y curl ffmpeg libsdl2-dev wget cmake git \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+RUN apt-get update \
+  && apt-get install -y curl ffmpeg wget \
+  && apt autoremove -y \
+  && apt clean -y \
+  && rm -rf /tmp/* /var/tmp/* \
+  && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+  && find /var/cache -type f -delete
 
-COPY --from=build /app /app
-ENV PATH=/app/build/bin:$PATH
+COPY --from=build /app/build/bin /app
+COPY --from=build /app/lib /app
+COPY --from=build /app/models /app/models
+
+ENV PATH=/app:$PATH
 ENTRYPOINT [ "bash", "-c" ]

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,17 @@
-build*/
+*.o
+*.a
+.cache/
+# Do not ignore .git directory, otherwise the reported build number will always be 0
 .github/
+.gitignore
+.vs/
+.vscode/
+.DS_Store
+*.md
+*.cmd
+
+build*/
 .devops/
+models/*.bin
+samples/
+tests/


### PR DESCRIPTION
The current docker images include the base model as well as tests, git repository etc which might not be needed inside the image.
This PR updates the cpu and vulkan images base ubuntu version to 24.04 and adds paths to the dockerignore file to exclude what seems to be unnecessary stuff.

The result is:
~300MB reduction in the cpu image size
~800MB reduction in the vulkan image size