### PR TITLE
Add cross-attention accessor functions for AlignAtt streaming

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -339,6 +339,27 @@ extern "C" {
                                int   n_past,
                                int   n_threads);
 
+    // Same as whisper_decode_with_state, but saves alignment head cross-attention data.
+    // Requires context created with dtw_token_timestamps=true and flash_attn=false.
+    WHISPER_API int whisper_decode_with_state_and_aheads(
+            struct whisper_context * ctx,
+              struct whisper_state * state,
+               const whisper_token * tokens,
+                               int   n_tokens,
+                               int   n_past,
+                               int   n_threads);
+
+    // Get cross-attention data from alignment heads after a decode call with aheads enabled.
+    // Returns pointer to float array of shape [n_tokens x n_audio_ctx x n_heads].
+    // Copies data from GPU/backend to CPU on each call.
+    // Returns NULL if DTW is not enabled or no attention data is available.
+    // The pointer is valid until the next call to this function or whisper_free_state.
+    WHISPER_API const float * whisper_state_get_aheads_cross_qks(
+              struct whisper_state * state,
+                               int * n_tokens,
+                               int * n_audio_ctx,
+                               int * n_heads);
+
     // Convert the provided text into tokens.
     // The tokens pointer must be large enough to hold the resulting tokens.
     // Returns the number of tokens on success, no more than n_max_tokens


### PR DESCRIPTION
## Summary
- Adds `whisper_decode_with_state_and_aheads()` — same as `whisper_decode_with_state` but saves alignment head cross-attention data during decode
- Adds `whisper_state_get_aheads_cross_qks()` — reads the resulting cross-attention tensor from state, copying from GPU/backend to CPU

These enable external callers to implement AlignAtt-style streaming policies by accessing the cross-attention data that is currently only available internally via DTW timestamp computation.

## Motivation
Building a streaming speech-to-text system that uses cross-attention analysis (AlignAtt) to decide when to stop decoding and emit partial results. The existing API only exposes DTW timestamps as a post-processing step via `whisper_full`, but streaming requires access to the raw cross-attention data during manual decode loops.

## Details
- `whisper_decode_with_state_and_aheads` calls `whisper_decode_internal` with `save_aheads=true`, matching how `whisper_full` internally enables attention head saving for DTW
- `whisper_state_get_aheads_cross_qks` returns a float pointer of shape `[n_tokens × n_audio_ctx × n_heads]`, valid until the next call or `whisper_free_state`
- Requires `dtw_token_timestamps=true` in context params (same prerequisite as DTW timestamps)
- No changes to existing functions or data structures — purely additive