### PR TITLE
readme : fix duplicate word typo in VAD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,7 +755,7 @@ argument to `whisper-cli`. In addition to this option a VAD model is also
 required.
 
 The way this works is that first the audio samples are passed through
-the VAD model which will detect speech segments. Using this information the
+the VAD model which will detect speech segments. Using this information,
 only the speech segments that are detected are extracted from the original audio
 input and passed to whisper for processing. This reduces the amount of audio
 data that needs to be processed by whisper and can significantly speed up the


### PR DESCRIPTION
## Summary

The VAD section of the README contains a duplicate word that makes the sentence grammatically incorrect:

**Before:**
> Using this information the
> only the speech segments that are detected are extracted…

The word `the` is duplicated across lines, resulting in `…information the / only the speech…`.

**After:**
> Using this information,
> only the speech segments that are detected are extracted…

## Changes

- Replace the orphaned `the` at the end of a line with a comma so the sentence reads correctly.

Documentation-only change, no functional impact.