### PR TITLE
fix(go): handle EOF correctly in model download example of golang bidings

### DIFF
--- a/bindings/go/examples/go-model-download/main.go
+++ b/bindings/go/examples/go-model-download/main.go
@@ -282,13 +282,20 @@ func Download(ctx context.Context, p io.Writer, model, out string) (string, erro
 		default:
 			// Read body
 			n, err := resp.Body.Read(data)
+			if n > 0 {
+				if m, err := w.Write(data[:n]); err != nil {
+					return path, err
+				} else {
+					count += int64(m)
+				}
+			}
+
 			if err != nil {
-				DownloadReport(p, pct, count, resp.ContentLength)
+				if err == io.EOF {
+					DownloadReport(p, pct, count, resp.ContentLength)
+					return path, nil
+				}
 				return path, err
-			} else if m, err := w.Write(data[:n]); err != nil {
-				return path, err
-			} else {
-				count += int64(m)
 			}
 		}
 	}


### PR DESCRIPTION
  The Download function inside of golang bindings examples had bug in its read loop:

  Data loss on final read: Go's io.Reader contract allows Read to return n > 0
  bytes and io.EOF simultaneously (last chunk + end of stream). The original code
  checked the error before processing the written bytes, so the final chunk could be
  silently dropped and the model file is never fully downloaded. 

  **Before**: write happens only `if err == nil`, and `io.EOF` propagates as an error to the
  caller.
  **After**: bytes are written first (if any), then `io.EOF` is handled as successful
  completion.
