### PR TITLE
vad : add streaming detect + explicit state reset

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -695,6 +695,16 @@ extern "C" {
                            const float * samples,
                                    int   n_samples);
 
+    // Like whisper_vad_detect_speech, but does not reset LSTM state.
+    // Use for streaming: call whisper_vad_reset_state() between utterances.
+    WHISPER_API bool whisper_vad_detect_speech_no_reset(
+            struct whisper_vad_context * vctx,
+                           const float * samples,
+                                   int   n_samples);
+
+    // Reset LSTM hidden/cell states to zero.
+    WHISPER_API void whisper_vad_reset_state(struct whisper_vad_context * vctx);
+
     WHISPER_API int     whisper_vad_n_probs(struct whisper_vad_context * vctx);
     WHISPER_API float * whisper_vad_probs  (struct whisper_vad_context * vctx);
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -5083,7 +5083,11 @@ struct whisper_vad_context * whisper_vad_init_with_params(
     return vctx;
 }
 
-bool whisper_vad_detect_speech(
+void whisper_vad_reset_state(whisper_vad_context * vctx) {
+    ggml_backend_buffer_clear(vctx->buffer, 0);
+}
+
+bool whisper_vad_detect_speech_no_reset(
         struct whisper_vad_context * vctx,
         const float * samples,
         int n_samples) {
@@ -5094,9 +5098,6 @@ bool whisper_vad_detect_speech(
 
     WHISPER_LOG_INFO("%s: detecting speech in %d samples\n", __func__, n_samples);
     WHISPER_LOG_INFO("%s: n_chunks: %d\n", __func__, n_chunks);
-
-    // Reset LSTM hidden/cell states
-    ggml_backend_buffer_clear(vctx->buffer, 0);
 
     vctx->probs.resize(n_chunks);
     WHISPER_LOG_INFO("%s: props size: %u\n", __func__, n_chunks);
@@ -5163,6 +5164,14 @@ bool whisper_vad_detect_speech(
     ggml_backend_sched_reset(sched);
 
     return true;
+}
+
+bool whisper_vad_detect_speech(
+        struct whisper_vad_context * vctx,
+        const float * samples,
+        int n_samples) {
+    whisper_vad_reset_state(vctx);
+    return whisper_vad_detect_speech_no_reset(vctx, samples, n_samples);
 }
 
 int whisper_vad_segments_n_segments(struct whisper_vad_segments * segments) {


### PR DESCRIPTION
## Summary

- Add `whisper_vad_detect_speech_no_reset()` — identical to `whisper_vad_detect_speech` but does not reset LSTM hidden/cell state, enabling temporal continuity when calling per-chunk in a streaming loop
- Add `whisper_vad_reset_state()` — explicit state reset for use between utterances
- Refactor `whisper_vad_detect_speech` as a thin wrapper (reset + no_reset) — zero behavior change for existing callers

## Motivation

`whisper_vad_detect_speech` calls `ggml_backend_buffer_clear(vctx->buffer, 0)` on every invocation, which resets the Silero LSTM hidden/cell states. This is correct for batch processing (the current use case), but prevents temporal continuity when calling per-chunk in a streaming loop — the LSTM effectively degrades to a feedforward classifier with no memory between chunks.

For streaming applications that call VAD once per chunk (e.g. 512 samples at 16kHz = 32ms), the model needs to carry state across calls to make use of its recurrent architecture.

## Changes

Two new public API functions following existing naming conventions:

```c
// Like whisper_vad_detect_speech, but does not reset LSTM state.
// Use for streaming: call whisper_vad_reset_state() between utterances.
WHISPER_API bool whisper_vad_detect_speech_no_reset(
        struct whisper_vad_context * vctx,
        const float * samples,
        int   n_samples);

// Reset LSTM hidden/cell states to zero.
WHISPER_API void whisper_vad_reset_state(struct whisper_vad_context * vctx);
```

`whisper_vad_detect_speech` is now `reset + no_reset` — existing callers (including `whisper_vad_segments_from_samples`, `test-vad.cpp`, `examples/speech.cpp`) are completely unaffected.
