### PR TITLE
fix: replace deprecated openvino-dev with openvino>=2023.3.0 for Python 3.12+ compat

### DIFF
--- a/models/convert-whisper-to-openvino.py
+++ b/models/convert-whisper-to-openvino.py
@@ -2,7 +2,6 @@ import argparse
 import torch
 from whisper import load_model
 import os
-from openvino.tools import mo
 from openvino.frontend import FrontEndManager
 from openvino.runtime import serialize
 import shutil

--- a/models/requirements-openvino.txt
+++ b/models/requirements-openvino.txt
@@ -1,2 +1,2 @@
-openvino-dev[pytorch,onnx]
+openvino>=2023.3.0
 openai-whisper


### PR DESCRIPTION
The pip install step for OpenVINO support has been broken on Python 3.12 and later because `openvino-dev[pytorch,onnx]` - as shipped in the requirements file - resolves to versions that constrain numpy to `<1.26.0`. Building numpy 1.25.x fails on Python 3.12+ because `pkgutil.ImpImporter` was removed in that release and older numpy relied on it, producing the `AttributeError: module 'pkgutil' has no attribute 'ImpImporter'` error seen in the issue.

The right fix is to stop depending on `openvino-dev` entirely. Intel deprecated that package with the 2023.x cycle and will discontinue it with the 2025.0 release - their own release notes describe `openvino-dev` as a legacy compatibility shim and recommend migrating to the base `openvino` package. Starting from OpenVINO 2023.x, model conversion tools and all supported frontends (including ONNX and PyTorch) are bundled in the base `openvino` package. Pinning to `openvino>=2023.3.0` allows any numpy >= 1.16.6 with no upper-bound conflict, which means Python 3.12 and 3.13 can satisfy the constraint from their package repositories without building numpy from source.

The `[pytorch,onnx]` extras that were passed to `openvino-dev` are not needed with the base `openvino` package - those extras existed only to pull in optional model-conversion dependencies that are now built-in.

While looking at `convert-whisper-to-openvino.py`, there is also a stale `from openvino.tools import mo` import. The `mo` name is never referenced anywhere in the script - the encoder conversion uses `FrontEndManager` and `serialize` directly. Leaving that import would cause an `ImportError` with `openvino>=2023.x` because `openvino.tools.mo` lives in `openvino-dev`, not in the base package. Removing the unused import is the correct fix; nothing in the script needs `mo`.

Tested with:

```
pip install -r models/requirements-openvino.txt
python -c "from openvino.frontend import FrontEndManager; from openvino.runtime import serialize; print('imports OK')"
pip show openvino | grep -E 'Name|Version|Requires'
```

On Python 3.12 this previously failed at the `pip install` stage. With `openvino>=2023.3.0` the install completes and the runtime imports resolve correctly.

Fixes #3669