### PR TITLE
server: allow max_len to be used for any output format

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -935,7 +935,7 @@ int main(int argc, char ** argv) {
             wparams.logprob_thold    = params.logprob_thold;
 
             wparams.no_timestamps    = params.no_timestamps;
-            wparams.token_timestamps = !params.no_timestamps && params.response_format == vjson_format;
+            wparams.token_timestamps = !params.no_timestamps;
             wparams.no_context       = params.no_context;
 
             wparams.suppress_nst     = params.suppress_nst;


### PR DESCRIPTION
This restriction is not needed, so let's remove it. I'm especially interested in making in available for the `srt` format.

Example (using llama-swap)

```bash
curl https://llama.server.home.arpa/upstream/large-v1/inference \                          
  -H "Content-Type: multipart/form-data" \
  -F "file=@output.wav" \
  -F "response_format=xxxx" \
  -F "temperature=0.0" \
  -F "temperature_inc=0.2"  \
  -F "max_len=20" \
  -F "split_on_word=true"
```

## json

```json
{"text":" The birch canoe slid\n on the smooth planks.\n Glue the sheet to\n the dark lue\n background.\n"}
```

## text

```text
 The birch canoe slid
 on the smooth planks.
 Glue the sheet to
 the dark blue
 background.
```

## srt

```text

1
00:00:00,000 --> 00:00:01,470
 The birch canoe slid

2
00:00:01,470 --> 00:00:04,010
 on the smooth planks.

3
00:00:04,010 --> 00:00:05,100
 Glue the sheet to

4
00:00:05,100 --> 00:00:05,680
 the dark blue

5
00:00:05,680 --> 00:00:07,000
 background.
```

## verbose_json

```json
{"text":" The birch canoe slid\n on the smooth planks.\n Glue the sheet to\n the dark blue\n background.\n"}
```

## vtt

```text
WEBVTT

00:00:00.000 --> 00:00:01.470
 The birch canoe slid

00:00:01.470 --> 00:00:04.010
 on the smooth planks.

00:00:04.010 --> 00:00:05.100
 Glue the sheet to

00:00:05.100 --> 00:00:05.680
 the dark blue

00:00:05.680 --> 00:00:07.000
 background.
```