### PR TITLE
ruby : null-check

### DIFF
--- a/bindings/ruby/ext/ruby_whisper_context.c
+++ b/bindings/ruby/ext/ruby_whisper_context.c
@@ -377,7 +377,7 @@ parse_samples(VALUE *samples, VALUE *n_samples)
         }
         parsed.n_samples = (int)n_samples_size;
       } else {
-        rb_warn("unable to get a memory view. fallbacks to Ruby object");
+        rb_warn("unable to get a memory view. falls back to Ruby object");
         if (rb_respond_to(*samples, id_length)) {
           parsed.n_samples = NUM2INT(rb_funcall(*samples, id_length, 0));
         } else {


### PR DESCRIPTION
Hi,

I fixed a tiny null-check bug.
By this fix, my podcast's audio processing pipeline combined with whisper.cpp (VAD), Torch and ONNX in Ruby works fine, finally!

Thanks.