### PR TITLE
fix: use original segment length for vad_end time mapping

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6701,12 +6701,14 @@ static bool whisper_vad(
             int segment_start_samples = cs_to_samples(vad_segments->data[i].start);
             int segment_end_samples   = cs_to_samples(vad_segments->data[i].end);
 
+            segment_start_samples = std::min(segment_start_samples, n_samples - 1);
+            segment_end_samples   = std::min(segment_end_samples, n_samples - 1);
+            int original_segment_length = segment_end_samples - segment_start_samples;
+
             if (i < (int)vad_segments->data.size() - 1) {
-                segment_end_samples += overlap_samples;
+                segment_end_samples = std::min(segment_end_samples + overlap_samples, n_samples - 1);
             }
 
-            segment_start_samples = std::min(segment_start_samples, n_samples - 1);
-            segment_end_samples = std::min(segment_end_samples, n_samples - 1);
             int segment_length = segment_end_samples - segment_start_samples;
             if (segment_length > 0) {
                 whisper_state::vad_segment_info segment;
@@ -6715,7 +6717,7 @@ static bool whisper_vad(
                 segment.orig_end   = vad_segments->data[i].end;
 
                 segment.vad_start = samples_to_cs(offset);
-                segment.vad_end   = samples_to_cs(offset + segment_length);
+                segment.vad_end   = samples_to_cs(offset + original_segment_length);
 
                 // Add segment boundaries to mapping table
                 vad_time_mapping start_mapping = {segment.vad_start, segment.orig_start};


### PR DESCRIPTION
## Summary

- Fixes incorrect VAD timestamp mapping when overlap samples are appended to segments
- `vad_end` was calculated using the overlap-extended `segment_length`, but `orig_end` reflects the original VAD boundary without overlap, creating a ratio mismatch in the time interpolation
- Compute `original_segment_length` before overlap is added and use it for `vad_end`; the full `segment_length` (with overlap) is still used for the audio buffer copy and offset advancement

## Details

When `whisper_full_with_state` processes VAD segments, non-final segments get `overlap_samples` appended (line 6705 on master) for smoother model transitions. The bug is that `segment.vad_end` was set to `samples_to_cs(offset + segment_length)` where `segment_length` includes this overlap, while `segment.orig_end` is the raw VAD boundary without overlap.

This mismatch means the linear interpolation at lines 6740-6743:
```cpp
int64_t orig_time = segment.orig_start + (vad_elapsed * orig_total) / vad_total;
```
uses a `vad_total` that is too large relative to `orig_total`, causing all timestamps within the segment to be shifted earlier than they should be.

The fix moves the boundary clamping before overlap addition and computes `original_segment_length` from the un-extended boundaries. Only `vad_end` changes; the `memcpy` and `offset` advancement still use the overlap-inclusive `segment_length` so the audio buffer is unaffected.

Fixes #3683