### PR TITLE
fix: allow flash attention in encoder when DTW is enabled

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -2317,7 +2317,11 @@ static struct ggml_cgraph * whisper_build_graph_cross(
         struct ggml_tensor * k;
         struct ggml_tensor * v;
 
-        if (wctx.params.flash_attn) {
+        // Use non-flash layout for cross-attention KV when DTW is enabled,
+        // since DTW needs the explicit cross-attention weights (KQ_soft_max)
+        const bool flash_cross = wctx.params.flash_attn && !wctx.params.dtw_token_timestamps;
+
+        if (flash_cross) {
             k = ggml_view_1d(ctx0, wstate.kv_cross.k, n_state*n_ctx,
                     (ggml_element_size(wstate.kv_cross.k)*n_state)*(il*n_ctx_pad));
 
@@ -2677,7 +2681,11 @@ static struct ggml_cgraph * whisper_build_graph_decoder(
                         ggml_reshape_3d(ctx0, Qcur, n_state_head, n_head, n_tokens),
                         0, 2, 1, 3);
 
-            if (wctx.params.flash_attn) {
+            // Use non-flash path for cross-attention when DTW is enabled,
+            // since DTW needs the explicit cross-attention weights (KQ_soft_max)
+            const bool flash_cross = wctx.params.flash_attn && !wctx.params.dtw_token_timestamps;
+
+            if (flash_cross) {
                 struct ggml_tensor * Kcross =
                     ggml_view_3d(ctx0, wstate.kv_cross.k,
                             n_state_head, n_audio_ctx_pad, n_head,
@@ -3706,8 +3714,7 @@ struct whisper_context * whisper_init_with_params_no_state(struct whisper_model_
     ggml_time_init();
 
     if (params.flash_attn && params.dtw_token_timestamps) {
-        WHISPER_LOG_WARN("%s: dtw_token_timestamps is not supported with flash_attn - disabling\n", __func__);
-        params.dtw_token_timestamps = false;
+        WHISPER_LOG_INFO("%s: flash_attn with dtw - disabling flash attention for cross-attention only\n", __func__);
     }
 
     WHISPER_LOG_INFO("%s: use gpu    = %d\n", __func__, params.use_gpu);


### PR DESCRIPTION
## Summary

- DTW token timestamps no longer silently disabled when flash attention is enabled
- Flash attention remains active for encoder self-attention and decoder self-attention
- Only cross-attention falls back to the non-flash path (needed to extract KQ_soft_max weights for DTW)

## Details

Previously, `whisper_init_with_params_no_state` disabled DTW entirely when `flash_attn` was set:
```cpp
if (params.flash_attn && params.dtw_token_timestamps) {
    params.dtw_token_timestamps = false; // DTW silently disabled
}
```

DTW only needs the explicit cross-attention weights (`KQ_soft_max`) from the decoder, which the flash attention path doesn't produce (it fuses Q*K*V into one operation). The encoder self-attention and decoder self-attention don't interact with DTW at all.

The fix introduces a `flash_cross` flag (`flash_attn && !dtw_token_timestamps`) used at two matching locations:
1. **Encoder** (cross-attention KV storage layout) — determines how K/V are stored in `kv_cross`
2. **Decoder** (cross-attention computation) — determines whether to use the fused flash path or the explicit K*Q → softmax → KQV path

Both locations must use the same condition to keep the KV cache layout consistent.

## Test plan

- [x] Builds cleanly on macOS with Metal
- Functional testing requires a whisper model with DTW-compatible alignment heads

Fixes #3662