### PR TITLE
fix(docs): correct typos found during code review

### DIFF
--- a/examples/bench.wasm/README.md
+++ b/examples/bench.wasm/README.md
@@ -44,4 +44,4 @@ cp bin/libbench.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/command.wasm/README.md
+++ b/examples/command.wasm/README.md
@@ -44,4 +44,4 @@ cp bin/libcommand.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/command/command.cpp
+++ b/examples/command/command.cpp
@@ -117,7 +117,7 @@ void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params & para
     fprintf(stderr, "  -ps,        --print-special  [%-7s] print special tokens\n",                        params.print_special ? "true" : "false");
     fprintf(stderr, "  -pe,        --print-energy   [%-7s] print sound energy (for debugging)\n",          params.print_energy ? "true" : "false");
     fprintf(stderr, "  -ng,        --no-gpu         [%-7s] disable GPU\n",                                 params.use_gpu ? "false" : "true");
-    fprintf(stderr, "  -fa,        --flash-attn     [%-7s] enbale flash attention\n",                      params.flash_attn ? "true" : "false");
+    fprintf(stderr, "  -fa,        --flash-attn     [%-7s] enable flash attention\n",                      params.flash_attn ? "true" : "false");
     fprintf(stderr, "  -nfa,       --no-flash-attn  [%-7s] disable flash attention\n",                     params.flash_attn ? "false" : "true");
     fprintf(stderr, "  -l LANG,    --language LANG  [%-7s] spoken language\n",                             params.language.c_str());
     fprintf(stderr, "  -m FNAME,   --model FNAME    [%-7s] model path\n",                                  params.model.c_str());

--- a/examples/ffmpeg-transcode.cpp
+++ b/examples/ffmpeg-transcode.cpp
@@ -7,7 +7,7 @@
  * Copyright (C) 2024       William Tambellini <william.tambellini@gmail.com>
  */
 
-// Just for conveninent C++ API
+// Just for convenient C++ API
 #include <vector>
 #include <string>
 

--- a/examples/json.hpp
+++ b/examples/json.hpp
@@ -11227,7 +11227,7 @@ class binary_reader
                 }
                 if (is_ndarray) // ndarray dimensional vector can only contain integers, and can not embed another array
                 {
-                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimentional vector is not allowed", "size"), nullptr));
+                    return sax->parse_error(chars_read, get_token_string(), parse_error::create(113, chars_read, exception_message(input_format, "ndarray dimensional vector is not allowed", "size"), nullptr));
                 }
                 std::vector<size_t> dim;
                 if (JSON_HEDLEY_UNLIKELY(!get_ubjson_ndarray_size(dim)))

--- a/examples/lsp/README.md
+++ b/examples/lsp/README.md
@@ -31,7 +31,7 @@ The vim plugin was designed to closely follow the mnemonics of vim
 
 
 Keys corresponding to a string use that spoken value normally and when a motion is expected, but use the key itself when a character is expected.  
-Keys corresponding to a dict, like `i`, can have manual difinitions given to each possible commandset.
+Keys corresponding to a dict, like `i`, can have manual definitions given to each possible commandset.
 
 0 is normal (insert), 1 is motion (inside), 2 is it's usage as a single key ([till] i), and 3 is it's usage in an area selection (s -> [around] sentence)
 
@@ -89,7 +89,7 @@ Will return an error if any of the commands in the commandset have duplicate tok
 
 `guided`  
 `params.commandset_index` An index returned by a corresponding commandset registration. If not set, the most recently registered commandset is used.
-`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is recieved. This should be left blank unless you have a timestamp from a previous response.  
+`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is received. This should be left blank unless you have a timestamp from a previous response.  
 Responds with  
 `result.command_index` The numerical index (starting from 0) of the detected command in the selected commandset
 `result.command_text` A string containing the command as provided in the commandset
@@ -98,7 +98,7 @@ Responds with
 `unguided`  
 `params.no_context` Sets the corresponding whisper `no_context` param. Defaults to true. Might provide more accurate results for consecutive unguided transcriptions if those after the first are set to false.
 `params.prompt` If provided, sets the initial prompt used during transcription.
-`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is recieved. This should be left blank unless you have a timestamp from a previous response.  
+`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is received. This should be left blank unless you have a timestamp from a previous response.  
 Responds with  
 `result.transcription` A string containing the transcribed text.  N.B. This will almost always start with a space due to how text is tokenized.
 `result.timestamp` A positive unsigned integer that designates the point in time which audio stopped being processed at. Pass this timestamp back in a subsequent message to mask the latency of transcription.

--- a/examples/server/httplib.h
+++ b/examples/server/httplib.h
@@ -4439,7 +4439,7 @@ inline bool read_content_chunked(Stream &strm, T &x,
   // an empty line". https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1
   //
   // In '7.1.3. Decoding Chunked', however, the pseudo-code in the section
-  // does't care for the existence of the final CRLF. In other words, it seems
+  // doesn't care for the existence of the final CRLF. In other words, it seems
   // to be ok whether the final CRLF exists or not in the chunked data.
   // https://www.rfc-editor.org/rfc/rfc9112.html#section-7.1.3
   //

--- a/examples/stb_vorbis.c
+++ b/examples/stb_vorbis.c
@@ -90,7 +90,7 @@ extern "C" {
 
 // Individual stb_vorbis* handles are not thread-safe; you cannot decode from
 // them from multiple threads at the same time. However, you can have multiple
-// stb_vorbis* handles and decode from them independently in multiple thrads.
+// stb_vorbis* handles and decode from them independently in multiple threads.
 
 
 ///////////   MEMORY ALLOCATION

--- a/examples/stream.wasm/README.md
+++ b/examples/stream.wasm/README.md
@@ -42,4 +42,4 @@ cp bin/libstream.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -1,7 +1,7 @@
 # whisper.cpp/examples/stream
 
 This is a naive example of performing real-time inference on audio from your microphone.
-The `whisper-stream` tool samples the audio every half a second and runs the transcription continously.
+The `whisper-stream` tool samples the audio every half a second and runs the transcription continuously.
 More info is available in [issue #10](https://github.com/ggerganov/whisper.cpp/issues/10).
 
 ```bash

--- a/examples/sycl/README.md
+++ b/examples/sycl/README.md
@@ -6,11 +6,11 @@ This example program provide the tools for llama.cpp for SYCL on Intel GPU.
 
 |Tool Name| Function|Status|
 |-|-|-|
-|ls-sycl-device| List all SYCL devices with ID, compute capability, max work group size, ect.|Support|
+|ls-sycl-device| List all SYCL devices with ID, compute capability, max work group size, etc.|Support|
 
 ### ls-sycl-device
 
-List all SYCL devices with ID, compute capability, max work group size, ect.
+List all SYCL devices with ID, compute capability, max work group size, etc.
 
 1. Build the llama.cpp for SYCL for all targets.
 

--- a/examples/talk-llama/eleven-labs.py
+++ b/examples/talk-llama/eleven-labs.py
@@ -44,7 +44,7 @@ args = parser.parse_args()
 if not args.quick:
     import importlib.util
     if importlib.util.find_spec("elevenlabs") is None:
-        print("elevenlabs library is not installed, you can install it to your enviroment using 'pip install elevenlabs'")
+        print("elevenlabs library is not installed, you can install it to your environment using 'pip install elevenlabs'")
         sys.exit()
 
 from elevenlabs import voices, generate, play, save

--- a/examples/talk-llama/llama-kv-cache.h
+++ b/examples/talk-llama/llama-kv-cache.h
@@ -333,7 +333,7 @@ public:
     ggml_tensor * get_v(ggml_context * ctx, int32_t il) const;
 
     // store k_cur and v_cur in the cache based on the provided head location
-    // note: the heads in k_cur and v_cur should be layed out contiguously in memory
+    // note: the heads in k_cur and v_cur should be laid out contiguously in memory
     //   - k_cur  [n_embd_head_k, n_head_k, n_tokens]
     //   - k_idxs [n_tokens]
     //   - v_cur  [n_embd_head_v, n_head_v, n_tokens]

--- a/examples/vad-speech-segments/speech.cpp
+++ b/examples/vad-speech-segments/speech.cpp
@@ -122,7 +122,7 @@ int main(int argc, char ** argv) {
         return 3;
     }
 
-    // Get the the vad segements using the probabilities that have been computed
+    // Get the the vad segments using the probabilities that have been computed
     // previously and stored in the whisper_vad_context.
     struct whisper_vad_params params = whisper_vad_default_params();
     params.threshold = cli_params.vad_threshold;

--- a/examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js
+++ b/examples/wchess/wchess.wasm/chessboardjs-1.0.0/js/chessboard-1.0.0.js
@@ -1552,7 +1552,7 @@
     }
 
     widget.resize = function () {
-      // calulate the new square size
+      // calculate the new square size
       squareSize = calculateSquareSize()
 
       // set board width

--- a/examples/whisper.wasm/README.md
+++ b/examples/whisper.wasm/README.md
@@ -64,4 +64,4 @@ cp bin/libmain.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/ggml/src/ggml-hexagon/htp/hvx-div.h
+++ b/ggml/src/ggml-hexagon/htp/hvx-div.h
@@ -86,7 +86,7 @@ static inline void hvx_div_scalar_f16_uu(uint8_t * restrict dst, const uint8_t *
     hvx_div_scaler_f16_loop_body(HVX_UVector, HVX_UVector, hvx_vec_store_u);
 }
 
-// Compute div by using hvx_vec_inverse_f32_guard. Requires first by exapnding fp32 to fp16 and convert the result back to fp32.
+// Compute div by using hvx_vec_inverse_f32_guard. Requires first by expanding fp32 to fp16 and convert the result back to fp32.
 static inline HVX_Vector hvx_vec_div_f16_using_f32(HVX_Vector vec1, HVX_Vector vec2, HVX_Vector f32_nan_inf_mask, HVX_Vector vec_hf_one_1_0) {
 #if __HVX_ARCH__ < 79
     // Convert first input to fp32

--- a/ggml/src/ggml-hexagon/htp/matmul-ops.c
+++ b/ggml/src/ggml-hexagon/htp/matmul-ops.c
@@ -352,7 +352,7 @@ static void vec_dot_q4x4x2_q8x4x2_1x1(const int n, float * restrict s0, const vo
     // Apply scale to acc and accumulate into the row sum (qf32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    const uint32_t nloe = n % qk;  // num leftover elemements
+    const uint32_t nloe = n % qk;  // num leftover elements
 
     uint32_t i = 0;
     for (; i < nb; i++) {
@@ -433,7 +433,7 @@ static void vec_dot_q4x4x2_q8x4x2_2x1(const int n, float * restrict s0,
     // Apply scale to acc and accumulate into the row sum (qf32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    const uint32_t nloe = n % qk;  // num leftover elemements
+    const uint32_t nloe = n % qk;  // num leftover elements
 
     uint32_t i = 0;
     for (; i < nb; i++) {
@@ -651,7 +651,7 @@ static void vec_dot_q8x4x2_q8x4x2_1x1(const int n, float * restrict s0, const vo
     // Apply scale to acc and accumulate into the row sum (qf32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    int32_t        nloe = n % qk;  // num leftover elemements (must be signed)
+    int32_t        nloe = n % qk;  // num leftover elements (must be signed)
 
     uint32_t i = 0;
     for (; i < nb; i++) {
@@ -732,7 +732,7 @@ static void vec_dot_q8x4x2_q8x4x2_2x1(const int n, float * restrict s0,
     // Apply scale to acc and accumulate into the row sum (qf32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    int32_t        nloe = n % qk;  // num leftover elemements (must be signed)
+    int32_t        nloe = n % qk;  // num leftover elements (must be signed)
 
     uint32_t i = 0;
     for (; i < nb; i++) {
@@ -950,7 +950,7 @@ static void vec_dot_mxfp4x4x2_q8x4x2_1x1(const int n, float * restrict s0, const
     // Apply scale to acc and accumulate into the row sum (qf32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    int32_t        nloe = n % qk;  // num leftover elemements (must be signed)
+    int32_t        nloe = n % qk;  // num leftover elements (must be signed)
 
     uint32_t i = 0;
     for (; i < nb; i++) {
@@ -1061,7 +1061,7 @@ static void vec_dot_mxfp4x4x2_q8x4x2_2x1(const int n, float * restrict s0,
     // Apply scale to acc and accumulate into the row sum (f32).
 
     const uint32_t nb   = n / qk;  // num full blocks
-    int32_t        nloe = n % qk;  // num leftover elemements (must be signed)
+    int32_t        nloe = n % qk;  // num leftover elements (must be signed)
 
     uint32_t i = 0;
     for (; i < nb; i++) {

--- a/ggml/src/ggml-openvino/utils.h
+++ b/ggml/src/ggml-openvino/utils.h
@@ -50,7 +50,7 @@ struct ov_runtime_context {
     std::unordered_map<graph_key, std::vector<std::string>, graph_key_hash> ov_input_names_cache;
     std::unordered_map<graph_key, std::vector<std::string>, graph_key_hash> ov_output_names_cache;
     //TODO: Stateful is only supported for single request at a time.
-    //      Simultanous stateful inference request support to be added.
+    //      Simultaneous stateful inference request support to be added.
     size_t stateful_kv_size;
     std::map<std::string, std::string> kv_state_input_name_map;
 

--- a/ggml/src/ggml-sycl/fattn-vec.hpp
+++ b/ggml/src/ggml-sycl/fattn-vec.hpp
@@ -24,7 +24,7 @@ static constexpr int ggml_sycl_fattn_vec_get_nthreads_device() {
     return 128;
 }
 
-// Currenlty llvm with the amdgcn target dose not support unrolling loops
+// Currently llvm with the amdgcn target dose not support unrolling loops
 // that contain a break that can not be resolved at compile time.
 #ifdef __clang__
 #pragma clang diagnostic push

--- a/models/convert-pt-to-ggml.py
+++ b/models/convert-pt-to-ggml.py
@@ -174,7 +174,7 @@ def bytes_to_unicode():
     The reversible bpe codes work on unicode strings.
     This means you need a large # of unicode characters in your vocab if you want to avoid UNKs.
     When you're at something like a 10B token dataset you end up needing around 5K for decent coverage.
-    This is a signficant percentage of your normal, say, 32K bpe vocab.
+    This is a significant percentage of your normal, say, 32K bpe vocab.
     To avoid that, we want lookup tables between utf-8 bytes and unicode strings.
     And avoids mapping to whitespace/control characters the bpe code barfs on.
     """

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -8678,7 +8678,7 @@ static ggml_tensor * dtw_and_backtrace(ggml_context * ctx, ggml_tensor * x) {
     whisper_set_f32_nd(cost, 0, 0, 0, 0, 0.0);
 
     // dtw
-    // supposedly can be optmized by computing diagonals in parallel ?
+    // supposedly can be optimized by computing diagonals in parallel ?
     // Not sure it is worth it since x will be GENERATED_TOKENS*1500 size at most.
     for (int64_t j = 1; j < M + 1; ++j) {
         for (int64_t i = 1; i < N + 1; ++i) {
@@ -8806,7 +8806,7 @@ static void whisper_exp_compute_token_level_timestamps_dtw(
     WHISPER_ASSERT(n_frames <= n_audio_ctx * 2);
     WHISPER_ASSERT(ctx->params.dtw_aheads_preset != WHISPER_AHEADS_NONE);
 
-    // FIXME: Allocating mem everytime we call this func
+    // FIXME: Allocating mem every time we call this func
     // Our ggml buffer should be pre-allocated somewhere during init and reused
     // when we call this function
     struct ggml_init_params gparams = {
@@ -8877,7 +8877,7 @@ static void whisper_exp_compute_token_level_timestamps_dtw(
     }
 
     // Normalize - in original OpenAI code, this is done over dim=-2. In this case,
-    // we already permuted N_TOKENS dimension to columns on last loop, becase ggml_norm
+    // we already permuted N_TOKENS dimension to columns on last loop, because ggml_norm
     // operates over columns. Afterwards, permute to a shape that facilitates mean
     // operation (after median filter)
     // IN: Tensor with N_TOKENS*N_AUDIO_TOKENS*N_ALIGNMENT_HEADS dims

--- a/tests/test-vad.cpp
+++ b/tests/test-vad.cpp
@@ -70,7 +70,7 @@ int main() {
     struct whisper_vad_params params = whisper_vad_default_params();
     assert_default_params(params);
 
-    // Test speech probabilites
+    // Test speech probabilities
     test_detect_speech(vctx, params, pcmf32.data(), pcmf32.size());
 
     // Test speech timestamps (uses speech probabilities from above)

--- a/tests/test-whisper.js
+++ b/tests/test-whisper.js
@@ -4,7 +4,7 @@ factory().then(function(whisper) {
     var fs = require('fs');
 
     // to avoid reading WAV files and depending on some 3rd-party package, we read
-    // 32-bit float PCM directly. to genereate it:
+    // 32-bit float PCM directly. to generate it:
     //
     //   $ ffmpeg -i samples/jfk.wav -f f32le -acodec pcm_f32le samples/jfk.pcmf32
     //


### PR DESCRIPTION
Non-functional changes only:
- Fixed minor spelling mistakes in comments
- Corrected typos in user-facing strings
- No variables, logic, or functional code was modified.

Signed-off-by: Marcel Petrick <mail@marcelpetrick.it>