### PR TITLE
ggml-metal : fix crash on Metal buffer allocation failure

### DIFF
--- a/ggml/src/ggml-metal/ggml-metal.cpp
+++ b/ggml/src/ggml-metal/ggml-metal.cpp
@@ -196,6 +196,11 @@ static ggml_backend_buffer_t ggml_backend_metal_buffer_type_alloc_buffer(ggml_ba
     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)buft->device->context;
     ggml_metal_buffer_t res = ggml_metal_buffer_init(ctx_dev, size, shared);
 
+    if (res == NULL) {
+        GGML_LOG_ERROR("%s: error: failed to allocate Metal buffer of size %zu\n", __func__, size);
+        return NULL;
+    }
+
     ggml_backend_buffer_i buf_i = ggml_metal_buffer_is_shared(res)
         ? ggml_backend_metal_buffer_shared_i
         : ggml_backend_metal_buffer_private_i;
@@ -712,6 +717,11 @@ static ggml_backend_buffer_t ggml_backend_metal_device_buffer_mapped(ggml_backen
     ggml_metal_device_t ctx_dev = (ggml_metal_device_t)dev->context;
 
     ggml_metal_buffer_t res = ggml_metal_buffer_map(ctx_dev, ptr, size, max_tensor_size);
+
+    if (res == NULL) {
+        GGML_LOG_ERROR("%s: error: failed to map Metal buffer of size %zu\n", __func__, size);
+        return NULL;
+    }
 
     const ggml_metal_device_props * props_dev = ggml_metal_device_get_props(ctx_dev);
 


### PR DESCRIPTION
Fixes #3386

When Metal buffer allocation fails (e.g. under memory pressure from
running multiple models concurrently), `ggml_metal_buffer_init` returns
NULL. The callers `ggml_backend_metal_buffer_type_alloc_buffer` and
`ggml_backend_metal_device_buffer_mapped` dereference this without a
NULL check, causing a segfault.

The rest of the error propagation chain already handles NULL correctly:

    ggml_metal_buffer_init          → returns NULL on OOM
    ggml_backend_metal_buffer_type_alloc_buffer  ← missing NULL check (this PR)
    ggml_backend_metal_device_buffer_mapped       ← missing NULL check (this PR)
    ggml_vbuffer_alloc              → checks NULL, returns NULL
    ggml_gallocr_reserve_n_impl     → checks NULL, returns false
    ggml_backend_sched_alloc_graph  → propagates false
    whisper_full                    → returns error code to caller

## Changes

Add NULL checks after `ggml_metal_buffer_init` and `ggml_metal_buffer_map`
in `ggml-metal.cpp` so that allocation failures propagate as error codes
instead of crashing. Follows the same pattern used in the CPU backend
(`ggml_backend_cpu_buffer_type_alloc_buffer`).

## Test

Verified on M4 Pro (macOS, Metal):

| Test | Before | After |
|------|--------|-------|
| 1 MB allocation | OK | OK |
| 1 TB allocation (guaranteed fail) | SIGSEGV (exit 139) | NULL returned, graceful exit |
| Repeated 2 GB allocations until exhaustion | crash before reaching test | 32 allocations then NULL returned |