### PR TITLE
cli : merge tokens split across UTF-8 boundaries in JSON output

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -31,6 +31,33 @@ static void replace_all(std::string & s, const std::string & search, const std::
     }
 }
 
+// Returns the number of trailing continuation bytes still needed for `s` to end
+// on a complete UTF-8 codepoint. Returns 0 if the tail of `s` is already a
+// complete codepoint (or if the tail looks malformed and we should stop merging).
+// Used to merge whisper tokens whose bytes split a multi-byte UTF-8 character
+// (e.g. CJK), so the JSON output stays valid UTF-8. See issue #1798.
+static int utf8_trailing_bytes_needed(const std::string & s) {
+    const int n = (int) s.size();
+    int i = n - 1;
+    // walk back past continuation bytes (10xxxxxx)
+    while (i >= 0 && ((unsigned char) s[i] & 0xC0) == 0x80) {
+        --i;
+    }
+    if (i < 0) {
+        // all continuation bytes, or empty — nothing we can do
+        return 0;
+    }
+    const unsigned char c = (unsigned char) s[i];
+    int expected;
+    if      ((c & 0x80) == 0x00) expected = 1; // ASCII
+    else if ((c & 0xE0) == 0xC0) expected = 2;
+    else if ((c & 0xF0) == 0xE0) expected = 3;
+    else if ((c & 0xF8) == 0xF0) expected = 4;
+    else                         return 0;     // malformed lead, give up
+    const int have = n - i;
+    return have >= expected ? 0 : (expected - have);
+}
+
 // command-line parameters
 struct whisper_params {
     int32_t n_threads     = std::min(4, (int32_t) std::thread::hardware_concurrency());
@@ -738,18 +765,47 @@ static void output_json(
                     if (full) {
                         start_arr("tokens");
                         const int n = whisper_full_n_tokens(ctx, i);
-                        for (int j = 0; j < n; ++j) {
-                            auto token = whisper_full_get_token_data(ctx, i, j);
-                            start_obj(nullptr);
-                                value_s("text", whisper_token_to_str(ctx, token.id), false);
-                                if(token.t0 > -1 && token.t1 > -1) {
-                                    // If we have per-token timestamps, write them out
-                                    times_o(token.t0, token.t1, false);
+
+                        // Merge adjacent tokens whose bytes together form a
+                        // single UTF-8 codepoint. Multi-byte characters (CJK
+                        // in particular) can end up split across whisper
+                        // tokens, which used to produce invalid UTF-8 in the
+                        // JSON string. Refs issue #1798.
+                        struct merged_token {
+                            std::string        text;
+                            whisper_token_data data;
+                            int64_t            t1;
+                        };
+                        std::vector<merged_token> merged;
+                        merged.reserve(n);
+                        for (int j = 0; j < n; ) {
+                            auto tok = whisper_full_get_token_data(ctx, i, j);
+                            merged_token m{ whisper_token_to_str(ctx, tok.id), tok, tok.t1 };
+                            ++j;
+                            while (j < n && utf8_trailing_bytes_needed(m.text) > 0) {
+                                auto tok_next = whisper_full_get_token_data(ctx, i, j);
+                                m.text += whisper_token_to_str(ctx, tok_next.id);
+                                if (tok_next.t1 > -1) {
+                                    m.t1 = tok_next.t1;
                                 }
-                                value_i("id", token.id, false);
-                                value_f("p", token.p, false);
-                                value_f("t_dtw", token.t_dtw, true);
-                            end_obj(j == (n - 1));
+                                ++j;
+                            }
+                            merged.push_back(std::move(m));
+                        }
+
+                        const int nm = (int) merged.size();
+                        for (int j = 0; j < nm; ++j) {
+                            const auto & mt = merged[j];
+                            start_obj(nullptr);
+                                value_s("text", mt.text.c_str(), false);
+                                if (mt.data.t0 > -1 && mt.t1 > -1) {
+                                    // If we have per-token timestamps, write them out
+                                    times_o(mt.data.t0, mt.t1, false);
+                                }
+                                value_i("id", mt.data.id, false);
+                                value_f("p", mt.data.p, false);
+                                value_f("t_dtw", mt.data.t_dtw, true);
+                            end_obj(j == (nm - 1));
                         }
                         end_arr(!params.diarize && !params.tinydiarize);
                     }

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -35,7 +35,7 @@ static void replace_all(std::string & s, const std::string & search, const std::
 // on a complete UTF-8 codepoint. Returns 0 if the tail of `s` is already a
 // complete codepoint (or if the tail looks malformed and we should stop merging).
 // Used to merge whisper tokens whose bytes split a multi-byte UTF-8 character
-// (e.g. CJK), so the JSON output stays valid UTF-8. See issue #1798.
+// (e.g. CJK), so the JSON output stays valid UTF-8. See https://github.com/ggml-org/whisper.cpp/issues/1798.
 static int utf8_trailing_bytes_needed(const std::string & s) {
     const int n = (int) s.size();
     int i = n - 1;
@@ -49,11 +49,17 @@ static int utf8_trailing_bytes_needed(const std::string & s) {
     }
     const unsigned char c = (unsigned char) s[i];
     int expected;
-    if      ((c & 0x80) == 0x00) expected = 1; // ASCII
-    else if ((c & 0xE0) == 0xC0) expected = 2;
-    else if ((c & 0xF0) == 0xE0) expected = 3;
-    else if ((c & 0xF8) == 0xF0) expected = 4;
-    else                         return 0;     // malformed lead, give up
+    if ((c & 0x80) == 0x00) {
+        expected = 1; // ASCII
+    } else if ((c & 0xE0) == 0xC0) {
+        expected = 2;
+    } else if ((c & 0xF0) == 0xE0) {
+        expected = 3;
+    } else if ((c & 0xF8) == 0xF0) {
+        expected = 4;
+    } else {
+        return 0;     // malformed lead, give up
+    }
     const int have = n - i;
     return have >= expected ? 0 : (expected - have);
 }


### PR DESCRIPTION
When a multi-byte UTF-8 codepoint — most commonly a CJK character, which takes 3 bytes — happens to land across two or more adjacent whisper tokens, the `-ojf`/`--output-json-full` writer was emitting each partial-byte token as its own JSON string. That produces invalid UTF-8, and most downstream parsers rightly choke on it (reported in #1798).

### Root cause

`output_json` in `examples/cli/cli.cpp` iterates at the token level and writes one JSON object per token. The segment-level text helpers (`whisper_full_get_segment_text`) concatenate tokens first, so they're fine — only the per-token loop was broken.

### Fix

Two small additions to `examples/cli/cli.cpp`:

1. **`utf8_trailing_bytes_needed(const std::string &)`** — a static helper that walks back past UTF-8 continuation bytes, finds the last lead byte, and returns how many more continuation bytes are still expected (0 if the tail is already a complete codepoint or looks malformed).

2. **Merge loop in `output_json`** — before writing tokens, adjacent tokens are accumulated into a `std::vector<merged_token>` while the accumulated text still ends on an incomplete UTF-8 sequence. Each merged entry keeps the first token's `id`, `p`, and `t_dtw` and extends `t1` to the last absorbed token. The emission loop then runs over the merged list instead of raw tokens.

No public API change. No format change for codepoints that already fit in one token. Only `output_json` is touched; `output_score` writes tab-separated plain text and never had a JSON-validity issue, so it's left alone.

### Not a duplicate of #3619

PR #3619 (`feat(cli): add word-level LRC output with UTF-8 fix`) adds a new LRC output mode and includes a UTF-8 fix scoped to that new writer. It does not touch `output_json` or address the issue described in #1798. The two changes are independent.

### Testing

Standalone unit tests against the helper (all pass):
- empty string, pure ASCII → 0
- complete and incomplete 2-byte sequences (é)
- complete and incomplete 3-byte sequences (私, the CJK char from the bug report)
- all three partial states of a 4-byte emoji
- incremental merge simulation: 私 in three tokens → merges into one entry

Built cleanly against current master: `cmake --build build --target whisper-cli -j`, no new warnings in `cli.cpp`.