### PR TITLE
bench : sync submit-results URL to ggml-org

### DIFF
--- a/examples/bench.wasm/emscripten.cpp
+++ b/examples/bench.wasm/emscripten.cpp
@@ -45,7 +45,7 @@ void bench_main(size_t index) {
     fprintf(stderr, "\n");
     fprintf(stderr, "If you wish, you can submit these results here:\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  https://github.com/ggerganov/whisper.cpp/issues/89\n");
+    fprintf(stderr, "  https://github.com/ggml-org/whisper.cpp/issues/89\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Please include the following information:\n");
     fprintf(stderr, "\n");

--- a/examples/bench/bench.cpp
+++ b/examples/bench/bench.cpp
@@ -157,7 +157,7 @@ static int whisper_bench_full(const whisper_params & params) {
     fprintf(stderr, "\n");
     fprintf(stderr, "If you wish, you can submit these results here:\n");
     fprintf(stderr, "\n");
-    fprintf(stderr, "  https://github.com/ggerganov/whisper.cpp/issues/89\n");
+    fprintf(stderr, "  https://github.com/ggml-org/whisper.cpp/issues/89\n");
     fprintf(stderr, "\n");
     fprintf(stderr, "Please include the following information:\n");
     fprintf(stderr, "\n");


### PR DESCRIPTION
Sync the "submit your results here" URL printed by `whisper-bench` and `bench.wasm` to the current `ggml-org/whisper.cpp` organization.

`README.md` (line 671) and `examples/bench/README.md` (lines 7 and 43) already reference the new owner when they mention issue #89. The two remaining occurrences in source — `examples/bench/bench.cpp:160` and `examples/bench.wasm/emscripten.cpp:48` — were not updated at the time and still print the old `ggerganov/...` URL.

The old URL still redirects, so this is a cosmetic consistency fix, not a functional change.

Verified locally by rebuilding `whisper-bench` and confirming the printed URL now reads `https://github.com/ggml-org/whisper.cpp/issues/89`.