### PR TITLE
android : fix CPU variant fallback returning LITTLE cluster count

### DIFF
--- a/examples/whisper.android.java/app/src/main/java/com/whispercpp/java/whisper/CpuInfo.java
+++ b/examples/whisper.android.java/app/src/main/java/com/whispercpp/java/whisper/CpuInfo.java
@@ -51,7 +51,7 @@ public class CpuInfo {
   private int getHighPerfCpuCountByVariant() {
     List<Integer> variants = getCpuValues("CPU variant", line -> Integer.parseInt(line.trim().substring(line.indexOf("0x") + 2), 16));
     Log.d(LOG_TAG, "Binned cpu variants (variant, count): " + binnedValues(variants));
-    return countKeepingMin(variants);
+    return countDroppingMin(variants);
   }
 
   @RequiresApi(api = Build.VERSION_CODES.N)

--- a/examples/whisper.android/lib/src/main/java/com/whispercpp/whisper/WhisperCpuConfig.kt
+++ b/examples/whisper.android/lib/src/main/java/com/whispercpp/whisper/WhisperCpuConfig.kt
@@ -26,7 +26,7 @@ private class CpuInfo(private val lines: List<String>) {
     private fun getHighPerfCpuCountByVariant(): Int =
         getCpuValues(property = "CPU variant") { it.substringAfter("0x").toInt(radix = 16) }
             .also { Log.d(LOG_TAG, "Binned cpu variants (variant, count): ${it.binnedValues()}") }
-            .countKeepingMin()
+            .countDroppingMin()
 
     private fun List<Int>.binnedValues() = groupingBy { it }.eachCount()
 


### PR DESCRIPTION
## Summary

The variant fallback in `getHighPerfCpuCountByVariant()` used `countKeepingMin()` while the primary frequency branch used `countDroppingMin()`. Both branches are meant to return the count of high-performance cores, so the asymmetry caused the variant branch to return the **LITTLE** cluster count instead of the big cluster.

On big.LITTLE SoCs, when `/sys/devices/system/cpu/cpuN/cpufreq/cpuinfo_max_freq` is unreadable (some restrictive Android distributions block it) and the code falls back to `CPU variant`, whisper ends up pinned to the LITTLE cores and inference throughput roughly halves.

Verified on Helio G85 by the reporter of #3602.

## The asymmetry

Before this PR, in both `WhisperCpuConfig.kt` and `CpuInfo.java`:

```kotlin
// frequency branch — returns high-perf core count ✓
private fun getHighPerfCpuCountByFrequencies(): Int =
    getCpuValues(property = \"processor\") { getMaxCpuFrequency(it.toInt()) }
        .countDroppingMin()

// variant fallback — returns LITTLE core count ✗
private fun getHighPerfCpuCountByVariant(): Int =
    getCpuValues(property = \"CPU variant\") { it.substringAfter(\"0x\").toInt(radix = 16) }
        .countKeepingMin()   // ← counts cores WITH the min value (LITTLE cluster)
```

The two helpers are:

```kotlin
private fun List<Int>.countDroppingMin(): Int = count { it > min() }   // high-perf cores
private fun List<Int>.countKeepingMin(): Int = count { it == min() }   // LITTLE cores
```

## Fix

Swap `countKeepingMin()` → `countDroppingMin()` in the variant branch of both the Kotlin (`whisper.android`) and Java (`whisper.android.java`) examples. Matches the suggestion in #3602.

## Test plan

- [x] ${\textsf{git diff}}$ is a 2-line change in 2 files
- [x] Manually re-read both files to confirm the frequency branch already uses `countDroppingMin()` — the fix restores symmetry rather than introducing a new behavior
- [ ] Real-device verification was done by the issue reporter on Helio G85; I do not have a big.LITTLE Android device to retest

Fixes #3602