### PR TITLE
server: Fix params leak between requests

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -817,7 +817,7 @@ int main(int argc, char ** argv) {
         }
         auto audio_file = req.get_file_value("file");
 
-        // check non-required fields
+        whisper_params params = default_params;
         get_req_parameters(req, params);
 
         std::string filename{audio_file.filename};
@@ -1120,9 +1120,6 @@ int main(int argc, char ** argv) {
             res.set_content(jres.dump(-1, ' ', false, json::error_handler_t::replace),
                             "application/json");
         }
-
-        // reset params to their defaults
-        params = default_params;
     });
     svr->Post(sparams.request_path + "/load", [&](const Request &req, Response &res){
         std::lock_guard<std::mutex> lock(whisper_mutex);


### PR DESCRIPTION
Example:

1. Request A sends bad audio, but also includes:
   ```bash
   -F carry_initial_prompt="true" \
   -F prompt="Always spell Kubernetes as K8s"
   ```

2. The server parses those fields into the shared `params`.

3. Then Request A fails while reading the audio and returns early.

4. Before the fix, the server never reached:
   ```cpp
   params = default_params;
   ```

5. Request B sends a normal transcription request without any prompt.

6. The server could still use Request A’s stale settings, so Request B may unexpectedly behave as if it had:
   ```bash
   -F carry_initial_prompt="true" \
   -F prompt="Always spell Kubernetes as K8s"
   ```

That is confusing because Request B did nothing wrong, but its output can be influenced by a previous failed request. The fix makes every request start from a fresh local copy of the default params, so failed requests cannot contaminate later ones.