### PR TITLE
Fix #984: About max_tokens skipping remaining audio issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -662,6 +662,7 @@ jobs:
         with:
           name: ggml_${{ matrix.arch }}.dll
           path: build/bin/${{ matrix.build }}/ggml.dll
+          overwrite: true
 
       - name: Upload ggml base dll
         uses: actions/upload-artifact@v6

--- a/bindings/go/pkg/whisper/context_test.go
+++ b/bindings/go/pkg/whisper/context_test.go
@@ -2,6 +2,7 @@ package whisper_test
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ggerganov/whisper.cpp/bindings/go/pkg/whisper"
@@ -90,6 +91,53 @@ func TestProcess(t *testing.T) {
 
 	err = context.Process(data, nil, nil, nil)
 	assert.NoError(err)
+}
+
+func TestProcessMaxTokensPerSegment(t *testing.T) {
+	assert := assert.New(t)
+
+	if _, err := os.Stat(ModelPath); os.IsNotExist(err) {
+		t.Skip("Skipping test, model not found:", ModelPath)
+	}
+
+	fh, err := os.Open(SamplePath)
+	assert.NoError(err)
+	defer fh.Close()
+
+	// Decode the WAV file - load the full buffer
+	dec := wav.NewDecoder(fh)
+	buf, err := dec.FullPCMBuffer()
+	assert.NoError(err)
+	assert.Equal(uint16(1), dec.NumChans)
+
+	data := buf.AsFloat32Buffer().Data
+
+	model, err := whisper.New(ModelPath)
+	assert.NoError(err)
+	assert.NotNil(model)
+	defer model.Close()
+
+	context, err := model.NewContext()
+	assert.NoError(err)
+
+	context.SetMaxTokensPerSegment(5)
+
+	err = context.Process(data, nil, nil, nil)
+	assert.NoError(err)
+
+	var text strings.Builder
+	nSegments := 0
+	for {
+		segment, err := context.NextSegment()
+		if err != nil {
+			break
+		}
+		nSegments++
+		text.WriteString(segment.Text)
+	}
+
+	assert.Greater(nSegments, 1)
+	assert.Contains(text.String(), "country")
 }
 
 func TestDetectedLanguage(t *testing.T) {

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6216,6 +6216,12 @@ static void whisper_process_logits(
             }
         }
 
+        if (!params.no_timestamps && !params.single_segment && params.max_tokens > 0 && (int) tokens_cur.size() >= params.max_tokens) {
+            for (int i = 0; i < vocab.token_eot; ++i) {
+                logits[i] = -INFINITY;
+            }
+        }
+
         // suppress sot and nosp tokens
         logits[vocab.token_sot]  = -INFINITY;
         logits[vocab.token_nosp] = -INFINITY;
@@ -7722,7 +7728,12 @@ int whisper_full_with_state(
             }
 
             // ref: https://github.com/ggml-org/whisper.cpp/pull/2629
+            const bool max_tokens_timestamp_ending = params.max_tokens > 0 &&
+                !params.single_segment &&
+                tokens_cur.size() > (size_t) params.max_tokens;
+
             const bool single_timestamp_ending = tokens_cur.size() > 1 &&
+                !max_tokens_timestamp_ending &&
                 tokens_cur[tokens_cur.size() - 2].id < whisper_token_beg(ctx) &&
                 tokens_cur[tokens_cur.size() - 1].id > whisper_token_beg(ctx);
             if (single_timestamp_ending) {

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6216,6 +6216,7 @@ static void whisper_process_logits(
             }
         }
 
+        // ref: https://github.com/ggml-org/whisper.cpp/pull/3798
         if (!params.no_timestamps && !params.single_segment && params.max_tokens > 0 && (int) tokens_cur.size() >= params.max_tokens) {
             for (int i = 0; i < vocab.token_eot; ++i) {
                 logits[i] = -INFINITY;


### PR DESCRIPTION
When a user sets a limit via `max_tokens` (e.g., through Go bindings' `SetMaxTokensPerSegment()`), the transcription often terminates prematurely. This happens because if the token limit is hit before a natural timestamp token is generated, the decoder finishes the current segment but leaves `seek_delta` pointing to the end of the current 30s audio chunk. Consequently, the `seek` pointer skips the remainder of the audio, returning only the first truncated segment.

This patch changes the decoding behavior for normal timestamped transcription:

- when `max_tokens` is reached, suppress text tokens so the next sampled token is a timestamp
- use that timestamp as the segment boundary
- avoid treating this forced timestamp ending as the special `single_timestamp_ending` case that skips the full chunk

The existing behavior for `single_segment` and `no_timestamps` is left unchanged.

Added a Go regression test that sets `SetMaxTokensPerSegment(5)` on the JFK sample and checks that more than one segment is returned and later text is still present.

Tested locally with `ggml-small.en.bin`:

Before:

```text
[0s->30s] And so, my fellow
```

After:

```text
[0s->1.04s]  And so, my
[1.04s->3.84s]  fellow Americans, ask
[3.84s->6.34s]  not what your country
[6.34s->8.1s]  can do for you
[8.1s->9.38s]  ask what you can
[9.38s->12.38s]  do for your country
```

Regression test:

```text
--- PASS: TestProcessMaxTokensPerSegment
PASS
```
