### PR TITLE
whisper : NULL-guard CPU device lookup in make_buft_list (fix #3497)

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -171,6 +171,13 @@ static bool ggml_graph_compute_helper(
          ggml_abort_callback   abort_callback,
                         void * abort_callback_data) {
     ggml_backend_ptr backend { ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr) };
+    if (!backend) {
+        // No CPU backend registered (GGML_BACKEND_DL=ON without a prior
+        // ggml_backend_load_all() call). Avoid the NULL deref a few lines
+        // below and surface the failure instead of aborting.
+        WHISPER_LOG_ERROR("%s: failed to initialize CPU backend\n", __func__);
+        return false;
+    }
 
     auto * reg = ggml_backend_dev_backend_reg(ggml_backend_get_device(backend.get()));
 
@@ -1386,6 +1393,20 @@ static buft_list_t make_buft_list(whisper_context_params & params) {
 
     // CPU Extra
     auto * cpu_dev = ggml_backend_dev_by_type(GGML_BACKEND_DEVICE_TYPE_CPU);
+    if (cpu_dev == nullptr) {
+        // No CPU backend registered in the GGML registry. This can happen with
+        // GGML_BACKEND_DL=ON builds when the host process has not loaded any
+        // CPU backend DLL via `ggml_backend_load*()` before reaching this code
+        // path (e.g. `whisper_init_*` or `whisper_vad_init_*` called before any
+        // explicit backend load). Without this guard, the next line aborts
+        // the process via `GGML_ASSERT(device != NULL)`. Returning an empty
+        // buft_list lets the caller surface a NULL whisper context instead.
+        WHISPER_LOG_ERROR("%s: no CPU backend device registered; "
+            "load a CPU backend with ggml_backend_load_all() or "
+            "ggml_backend_load() before initializing the whisper context\n",
+            __func__);
+        return {};
+    }
     auto * cpu_reg = ggml_backend_dev_backend_reg(cpu_dev);
     auto get_extra_bufts_fn = (ggml_backend_dev_get_extra_bufts_t)
         ggml_backend_reg_get_proc_address(cpu_reg, "ggml_backend_dev_get_extra_bufts");
@@ -8937,6 +8958,13 @@ static void whisper_exp_compute_token_level_timestamps_dtw(
     ggml_build_forward_expand(gf, w);
 
     ggml_backend_ptr backend { ggml_backend_init_by_type(GGML_BACKEND_DEVICE_TYPE_CPU, nullptr) };
+    if (!backend) {
+        // No CPU backend registered (GGML_BACKEND_DL=ON without a prior
+        // ggml_backend_load_all() call). Skip DTW alignment for this
+        // segment instead of aborting the whole process.
+        WHISPER_LOG_ERROR("%s: failed to initialize CPU backend for DTW; skipping token-level timestamps\n", __func__);
+        return;
+    }
     ggml_backend_graph_compute(backend.get(), gf);
 
     ggml_tensor * alignment = dtw_and_backtrace(gctx, w);


### PR DESCRIPTION
## Summary

Three call sites in \`src/whisper.cpp\` dereference the CPU backend device returned by GGML without checking for NULL. With \`GGML_BACKEND_DL=ON\` builds, the registry starts empty (no backend is statically linked into \`ggml-base\`), and an embedder that calls \`whisper_init_*\` or \`whisper_vad_init_*\` **before** an explicit \`ggml_backend_load*()\` invocation hits \`GGML_ASSERT(device != NULL)\` inside \`ggml_backend_dev_backend_reg\`. On Windows the process is killed with \`__fastfail(7)\` (status \`0xC0000409\`, \`FAST_FAIL_FATAL_APP_EXIT\`) with no chance for the application to recover.

Closes #3497 (same symptom, Flutter Windows embedder).

## Repro

Any \`BUILD_SHARED_LIBS=ON\` + \`GGML_BACKEND_DL=ON\` build, on a host without a CPU backend DLL pre-loaded by \`ggml_backend_load_all()\`:

\`\`\`c
// 1. Process starts. ggml-base.dll registry is empty (no static GGML_USE_CPU).
// 2. Embedder calls:
struct whisper_vad_context_params p = whisper_vad_default_context_params();
p.use_gpu = false;
whisper_vad_init_from_file_with_params(\"silero.gguf\", p);
// → make_buft_list → ggml_backend_dev_by_type(CPU) → NULL
// → ggml_backend_dev_backend_reg(NULL) → assert → __fastfail(7)
\`\`\`

I hit this on a Windows MSI build that calls \`whisper_vad_init_from_file_with_params\` for Silero VAD before the main \`whisper_init_*\`. Full WinDbg dump + stack trace at https://github.com/TheBlueHouse75/simple-flow/tree/report/whisper-rs-vad-gpu-null-2026-05-19/reports/windows-whisper-rs-vad-gpu-null-2026-05-19 .

## Patch

| Site | Line (current master) | Function | Behavior |
|---|---|---|---|
| 1 | 173 | \`ggml_graph_compute_helper\` (CPU helper) | NULL-check \`backend\`, return \`false\` |
| 2 | 1388 | \`make_buft_list\` (called by \`whisper_init_*\` and \`whisper_vad_init_*\`) | NULL-check \`cpu_dev\`, return empty \`buft_list\` |
| 3 | 8960 | \`whisper_exp_compute_token_level_timestamps_dtw\` | NULL-check \`backend\`, early \`return\` (skip DTW for this segment) |

All three log a clear \`WHISPER_LOG_ERROR\` message pointing embedders at \`ggml_backend_load_all()\` / \`ggml_backend_load()\` as the fix on their side. This mirrors the existing NULL-guard already present at line 1352 (\`whisper_backend_init\`).

## Test plan

- [x] CMake configure + build of \`whisper\` target on macOS (Accelerate + Metal), 0 warning, 0 new error.
- [ ] Build on Windows with \`BUILD_SHARED_LIBS=ON\` + \`GGML_BACKEND_DL=ON\`, confirm the \`__fastfail(7)\` is replaced by a clean WHISPER_LOG_ERROR + NULL context return.
- [ ] No regression on a default (GGML_BACKEND_DL=OFF) build that has a CPU backend statically registered (the guards take the happy path).

## Why this matters

\`GGML_ASSERT(device != NULL)\` is the right invariant for internal code, but the C public API (\`whisper_init_*\`, \`whisper_vad_init_*\`) is reachable by embedders that may not know they must call \`ggml_backend_load_all()\` first — especially with the new VAD entry points (\`whisper_vad_init_from_file_with_params\`) shipped in 1.8.x. A process abort from inside a public C API call is hard to recover from for any high-level binding (Flutter, Rust, Python, …). Returning a NULL context + logging the error lets the binding surface a typed error to userland.

Happy to refactor (e.g. extract a shared \`get_cpu_backend_or_log\` helper) if you'd prefer. Kept the patches local and small for review.