### PR TITLE
constrain auto-detect to a provided set of candidate languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ The command downloads the `base.en` model converted to custom `ggml` format and 
 
 For detailed usage instructions, run: `./build/bin/whisper-cli -h`
 
+If you want auto-detect to choose from a known subset of languages, use `--language auto` together with `--language-candidates`. For example, to constrain detection to Indonesian or Arabic and prevent fallback to another languages such as Malay from being selected:
+
+```bash
+./build/bin/whisper-cli -m models/ggml-base.bin --language auto --language-candidates id,ar -f input.wav
+```
+
+If you already know the exact language, prefer a fixed language such as `--language id` instead of auto-detect.
+
 Note that the [whisper-cli](examples/cli) example currently runs only with 16-bit WAV files, so make sure to convert your input before running the tool.
 For example, you can use `ffmpeg` like this:
 

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -50,6 +50,7 @@ options:
   -nt,       --no-timestamps     [false  ] do not print timestamps
   -l LANG,   --language LANG     [en     ] spoken language ('auto' for auto-detect)
   -dl,       --detect-language   [false  ] exit after automatically detecting language
+             --language-candidates [      ] comma-separated language codes for constrained auto-detect
              --prompt PROMPT     [       ] initial prompt (max n_text_ctx/2 tokens)
   -m FNAME,  --model FNAME       [models/ggml-base.en.bin] model path
   -f FNAME,  --file FNAME        [       ] input audio file path

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -163,33 +163,33 @@ static char * requires_value_error(const std::string & arg) {
     exit(0);
 }
 
-static std::vector<std::string> split_language_candidates(const std::string & input) {
+static std::vector<std::string> string_split(const std::string & input, char separator) {
     std::vector<std::string> result;
     size_t start = 0;
 
     while (start <= input.size()) {
-        const size_t comma = input.find(',', start);
-        const std::string token = input.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
+        const size_t next = input.find(separator, start);
+        const std::string token = input.substr(start, next == std::string::npos ? std::string::npos : next - start);
         result.push_back(token);
 
-        if (comma == std::string::npos) {
+        if (next == std::string::npos) {
             break;
         }
 
-        start = comma + 1;
+        start = next + 1;
     }
 
     return result;
 }
 
-static std::string join_language_candidates(const std::vector<std::string> & candidates) {
+static std::string string_join(const std::vector<std::string> & values, const std::string & separator) {
     std::string joined;
 
-    for (size_t i = 0; i < candidates.size(); ++i) {
+    for (size_t i = 0; i < values.size(); ++i) {
         if (i > 0) {
-            joined += ",";
+            joined += separator;
         }
-        joined += candidates[i];
+        joined += values[i];
     }
 
     return joined;
@@ -259,7 +259,7 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-l"    || arg == "--language")             { params.language        = whisper_param_turn_lowercase(ARGV_NEXT); }
         else if (arg == "-dl"   || arg == "--detect-language")      { params.detect_language = true; }
         else if (                  arg == "--language-candidates")  {
-            params.language_candidates = split_language_candidates(whisper_param_turn_lowercase(ARGV_NEXT));
+            params.language_candidates = string_split(whisper_param_turn_lowercase(ARGV_NEXT), ',');
         }
         else if (                  arg == "--prompt")               { params.prompt          = ARGV_NEXT; }
         else if (                  arg == "--carry-initial-prompt") { params.carry_initial_prompt = true; }
@@ -343,7 +343,7 @@ static void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params
     fprintf(stderr, "  -nt,       --no-timestamps        [%-7s] do not print timestamps\n",                        params.no_timestamps ? "true" : "false");
     fprintf(stderr, "  -l LANG,   --language LANG        [%-7s] spoken language ('auto' for auto-detect)\n",       params.language.c_str());
     fprintf(stderr, "  -dl,       --detect-language      [%-7s] exit after automatically detecting language\n",    params.detect_language ? "true" : "false");
-    fprintf(stderr, "             --language-candidates  [%-7s] comma-separated language codes for constrained auto-detect\n", join_language_candidates(params.language_candidates).c_str());
+    fprintf(stderr, "             --language-candidates  [%-7s] comma-separated language codes for constrained auto-detect\n", string_join(params.language_candidates, ",").c_str());
     fprintf(stderr, "             --prompt PROMPT        [%-7s] initial prompt (max n_text_ctx/2 tokens)\n",       params.prompt.c_str());
     fprintf(stderr, "             --carry-initial-prompt [%-7s] always prepend initial prompt\n",                  params.carry_initial_prompt ? "true" : "false");
     fprintf(stderr, "  -m FNAME,  --model FNAME          [%-7s] model path\n",                                     params.model.c_str());
@@ -1278,7 +1278,7 @@ int main(int argc, char ** argv) {
         }
 
         if (!params.no_prints) {
-            const std::string candidate_summary = join_language_candidates(params.language_candidates);
+            const std::string candidate_summary = string_join(params.language_candidates, ",");
             // print system information
             fprintf(stderr, "\n");
             fprintf(stderr, "system_info: n_threads = %d / %d | %s\n",

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -115,6 +115,7 @@ struct whisper_params {
     bool carry_initial_prompt = false;
 
     std::string language  = "en";
+    std::vector<std::string> language_candidates = {};
     std::string prompt;
     std::string font_path = "/System/Library/Fonts/Supplemental/Courier New Bold.ttf";
     std::string model     = "models/ggml-base.en.bin";
@@ -160,6 +161,38 @@ static char * whisper_param_turn_lowercase(char * in){
 static char * requires_value_error(const std::string & arg) {
     fprintf(stderr, "error: argument %s requires value\n", arg.c_str());
     exit(0);
+}
+
+static std::vector<std::string> split_language_candidates(const std::string & input) {
+    std::vector<std::string> result;
+    size_t start = 0;
+
+    while (start <= input.size()) {
+        const size_t comma = input.find(',', start);
+        const std::string token = input.substr(start, comma == std::string::npos ? std::string::npos : comma - start);
+        result.push_back(token);
+
+        if (comma == std::string::npos) {
+            break;
+        }
+
+        start = comma + 1;
+    }
+
+    return result;
+}
+
+static std::string join_language_candidates(const std::vector<std::string> & candidates) {
+    std::string joined;
+
+    for (size_t i = 0; i < candidates.size(); ++i) {
+        if (i > 0) {
+            joined += ",";
+        }
+        joined += candidates[i];
+    }
+
+    return joined;
 }
 
 static bool whisper_params_parse(int argc, char ** argv, whisper_params & params) {
@@ -225,6 +258,9 @@ static bool whisper_params_parse(int argc, char ** argv, whisper_params & params
         else if (arg == "-nt"   || arg == "--no-timestamps")        { params.no_timestamps   = true; }
         else if (arg == "-l"    || arg == "--language")             { params.language        = whisper_param_turn_lowercase(ARGV_NEXT); }
         else if (arg == "-dl"   || arg == "--detect-language")      { params.detect_language = true; }
+        else if (                  arg == "--language-candidates")  {
+            params.language_candidates = split_language_candidates(whisper_param_turn_lowercase(ARGV_NEXT));
+        }
         else if (                  arg == "--prompt")               { params.prompt          = ARGV_NEXT; }
         else if (                  arg == "--carry-initial-prompt") { params.carry_initial_prompt = true; }
         else if (arg == "-m"    || arg == "--model")                { params.model           = ARGV_NEXT; }
@@ -307,6 +343,7 @@ static void whisper_print_usage(int /*argc*/, char ** argv, const whisper_params
     fprintf(stderr, "  -nt,       --no-timestamps        [%-7s] do not print timestamps\n",                        params.no_timestamps ? "true" : "false");
     fprintf(stderr, "  -l LANG,   --language LANG        [%-7s] spoken language ('auto' for auto-detect)\n",       params.language.c_str());
     fprintf(stderr, "  -dl,       --detect-language      [%-7s] exit after automatically detecting language\n",    params.detect_language ? "true" : "false");
+    fprintf(stderr, "             --language-candidates  [%-7s] comma-separated language codes for constrained auto-detect\n", join_language_candidates(params.language_candidates).c_str());
     fprintf(stderr, "             --prompt PROMPT        [%-7s] initial prompt (max n_text_ctx/2 tokens)\n",       params.prompt.c_str());
     fprintf(stderr, "             --carry-initial-prompt [%-7s] always prepend initial prompt\n",                  params.carry_initial_prompt ? "true" : "false");
     fprintf(stderr, "  -m FNAME,  --model FNAME          [%-7s] model path\n",                                     params.model.c_str());
@@ -715,6 +752,24 @@ static void output_json(
         end_value(end);
     };
 
+    auto value_arr_s = [&](const char * name, const std::vector<std::string> & vals, bool end) {
+        doindent();
+        fout << "\"" << name << "\": [";
+        if (!vals.empty()) {
+            fout << "\n";
+            indent++;
+            for (size_t i = 0; i < vals.size(); ++i) {
+                doindent();
+                char * val_escaped = escape_double_quotes_and_backslashes(vals[i].c_str());
+                fout << "\"" << val_escaped << "\"" << (i + 1 == vals.size() ? "\n" : ",\n");
+                free(val_escaped);
+            }
+            indent--;
+            doindent();
+        }
+        fout << "]" << (end ? "\n" : ",\n");
+    };
+
     auto times_o = [&](int64_t t0, int64_t t1, bool end) {
         start_obj("timestamps");
         value_s("from", to_timestamp(t0, true).c_str(), false);
@@ -750,6 +805,7 @@ static void output_json(
         start_obj("params");
             value_s("model", params.model.c_str(), false);
             value_s("language", params.language.c_str(), false);
+            value_arr_s("language_candidates", params.language_candidates, false);
             value_b("translate", params.translate, true);
         end_obj(false);
         start_obj("result");
@@ -1058,6 +1114,20 @@ int main(int argc, char ** argv) {
         exit(0);
     }
 
+    if (!params.language_candidates.empty() && params.language != "auto" && !params.detect_language) {
+        fprintf(stderr, "error: --language-candidates requires --language auto or --detect-language\n");
+        whisper_print_usage(argc, argv, params);
+        exit(0);
+    }
+
+    for (const auto & candidate : params.language_candidates) {
+        if (candidate.empty() || whisper_lang_id(candidate.c_str()) == -1) {
+            fprintf(stderr, "error: unknown language candidate '%s'\n", candidate.c_str());
+            whisper_print_usage(argc, argv, params);
+            exit(0);
+        }
+    }
+
     if (params.diarize && params.tinydiarize) {
         fprintf(stderr, "error: cannot use both --diarize and --tinydiarize\n");
         whisper_print_usage(argc, argv, params);
@@ -1102,6 +1172,12 @@ int main(int argc, char ** argv) {
 
     if (ctx == nullptr) {
         fprintf(stderr, "error: failed to initialize whisper context\n");
+        return 3;
+    }
+
+    if (!params.language_candidates.empty() && !whisper_is_multilingual(ctx)) {
+        fprintf(stderr, "error: --language-candidates requires a multilingual model\n");
+        whisper_free(ctx);
         return 3;
     }
 
@@ -1202,6 +1278,7 @@ int main(int argc, char ** argv) {
         }
 
         if (!params.no_prints) {
+            const std::string candidate_summary = join_language_candidates(params.language_candidates);
             // print system information
             fprintf(stderr, "\n");
             fprintf(stderr, "system_info: n_threads = %d / %d | %s\n",
@@ -1216,6 +1293,9 @@ int main(int argc, char ** argv) {
                     params.translate ? "translate" : "transcribe",
                     params.tinydiarize ? "tdrz = 1, " : "",
                     params.no_timestamps ? 0 : 1);
+            if (!candidate_summary.empty()) {
+                fprintf(stderr, "%s: constrained auto-detect candidates = %s\n", __func__, candidate_summary.c_str());
+            }
 
             if (params.print_colors) {
                 fprintf(stderr, "%s: color scheme: red (low confidence), yellow (medium), green (high confidence)\n", __func__);
@@ -1228,6 +1308,11 @@ int main(int argc, char ** argv) {
         // run the inference
         {
             whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+            std::vector<const char *> language_candidates;
+            language_candidates.reserve(params.language_candidates.size());
+            for (const auto & candidate : params.language_candidates) {
+                language_candidates.push_back(candidate.c_str());
+            }
 
             const bool use_grammar = (!params.grammar_parsed.rules.empty() && !params.grammar_rule.empty());
             wparams.strategy = (params.beam_size > 1 || use_grammar) ? WHISPER_SAMPLING_BEAM_SEARCH : WHISPER_SAMPLING_GREEDY;
@@ -1239,6 +1324,8 @@ int main(int argc, char ** argv) {
             wparams.translate        = params.translate;
             wparams.language         = params.language.c_str();
             wparams.detect_language  = params.detect_language;
+            wparams.language_candidates = language_candidates.empty() ? nullptr : language_candidates.data();
+            wparams.n_language_candidates = language_candidates.size();
             wparams.n_threads        = params.n_threads;
             wparams.n_max_text_ctx   = params.max_context >= 0 ? params.max_context : wparams.n_max_text_ctx;
             wparams.offset_ms        = params.offset_t_ms;

--- a/include/whisper.h
+++ b/include/whisper.h
@@ -381,11 +381,28 @@ extern "C" {
                                int   n_threads,
                              float * lang_probs);
 
+    WHISPER_API int whisper_lang_auto_detect_candidates(
+            struct whisper_context * ctx,
+                               int   offset_ms,
+                               int   n_threads,
+                     const char * const * language_candidates,
+                               int   n_language_candidates,
+                             float * lang_probs);
+
     WHISPER_API int whisper_lang_auto_detect_with_state(
             struct whisper_context * ctx,
               struct whisper_state * state,
                                int   offset_ms,
                                int   n_threads,
+                             float * lang_probs);
+
+    WHISPER_API int whisper_lang_auto_detect_with_state_candidates(
+            struct whisper_context * ctx,
+              struct whisper_state * state,
+                               int   offset_ms,
+                               int   n_threads,
+                     const char * const * language_candidates,
+                               int   n_language_candidates,
                              float * lang_probs);
 
     WHISPER_API int whisper_n_len           (struct whisper_context * ctx); // mel length
@@ -532,6 +549,8 @@ extern "C" {
         // for auto-detection, set to nullptr, "" or "auto"
         const char * language;
         bool detect_language;
+        const char * const * language_candidates;
+        int n_language_candidates;
 
         // common decoding parameters:
         bool suppress_blank; // ref: https://github.com/openai/whisper/blob/f82bc59f5ea234d4b97fb2860842ed38519f7e65/whisper/decoding.py#L89

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4018,7 +4018,7 @@ const char * whisper_lang_str_full(int id) {
     return nullptr;
 }
 
-static int whisper_lang_candidates_to_ids(
+int whisper_lang_candidates_to_ids(
         const char * func_name,
         const char * const * language_candidates,
         int n_language_candidates,
@@ -4069,14 +4069,14 @@ static int whisper_lang_candidates_to_ids(
 }
 
 static int whisper_lang_auto_detect_impl(
-        const char * func_name,
+                    const char * func_name,
         struct whisper_context * ctx,
-        struct whisper_state * state,
-        int offset_ms,
-        int n_threads,
-        const char * const * language_candidates,
-        int n_language_candidates,
-        float * lang_probs) {
+          struct whisper_state * state,
+                           int   offset_ms,
+                           int   n_threads,
+            const char * const * language_candidates,
+                           int   n_language_candidates,
+                         float * lang_probs) {
     if (n_language_candidates > 0 && !whisper_is_multilingual(ctx)) {
         WHISPER_LOG_ERROR("%s: constrained auto-detect requires a multilingual model\n", func_name);
         return -5;
@@ -4105,6 +4105,7 @@ static int whisper_lang_auto_detect_impl(
         return -2;
     }
 
+    // run the encoder
     if (whisper_encode_with_state(ctx, state, seek, n_threads) != 0) {
         WHISPER_LOG_ERROR("%s: failed to encode\n", func_name);
         return -6;
@@ -4126,30 +4127,58 @@ static int whisper_lang_auto_detect_impl(
         logits_id.emplace_back(state->logits[token_lang], lang_id);
     }
 
-    using pair_type = std::remove_reference<decltype(logits_id)>::type::value_type;
-    std::sort(logits_id.begin(), logits_id.end(), [](const pair_type & a, const pair_type & b) {
-        return a.first > b.first;
-    });
-
-    const auto max = logits_id[0].first;
-
-    double sum = 0.0f;
-    for (auto & kv : logits_id) {
-        kv.first = exp(kv.first - max);
-        sum += kv.first;
+    // sort descending
+    {
+        using pair_type = std::remove_reference<decltype(logits_id)>::type::value_type;
+        std::sort(logits_id.begin(), logits_id.end(), [](const pair_type & a, const pair_type & b) {
+            return a.first > b.first;
+        });
     }
 
-    for (auto & kv : logits_id) {
-        kv.first /= sum;
+    // softmax
+    {
+        const auto max = logits_id[0].first;
+
+        double sum = 0.0f;
+        for (auto & kv : logits_id) {
+            kv.first = exp(kv.first - max);
+            sum += kv.first;
+        }
+
+        for (auto & kv : logits_id) {
+            kv.first /= sum;
+        }
     }
 
-    for (const auto & prob : logits_id) {
-        if (lang_probs) {
-            lang_probs[prob.second] = prob.first;
+    {
+        for (const auto & prob : logits_id) {
+            if (lang_probs) {
+                lang_probs[prob.second] = prob.first;
+            }
+
+            //printf("%s: lang %2d (%3s): %f\n", func_name, prob.second, whisper_lang_str(prob.second), prob.first);
         }
     }
 
     return logits_id[0].second;
+}
+
+int whisper_lang_auto_detect(
+        struct whisper_context * ctx,
+                           int   offset_ms,
+                           int   n_threads,
+                         float * lang_probs) {
+    return whisper_lang_auto_detect_with_state(ctx, ctx->state, offset_ms, n_threads, lang_probs);
+}
+
+int whisper_lang_auto_detect_candidates(
+        struct whisper_context * ctx,
+                           int   offset_ms,
+                           int   n_threads,
+                 const char * const * language_candidates,
+                           int   n_language_candidates,
+                         float * lang_probs) {
+    return whisper_lang_auto_detect_with_state_candidates(ctx, ctx->state, offset_ms, n_threads, language_candidates, n_language_candidates, lang_probs);
 }
 
 int whisper_lang_auto_detect_with_state(
@@ -4170,24 +4199,6 @@ int whisper_lang_auto_detect_with_state_candidates(
                            int   n_language_candidates,
                          float * lang_probs) {
     return whisper_lang_auto_detect_impl(__func__, ctx, state, offset_ms, n_threads, language_candidates, n_language_candidates, lang_probs);
-}
-
-int whisper_lang_auto_detect(
-        struct whisper_context * ctx,
-                           int   offset_ms,
-                           int   n_threads,
-                         float * lang_probs) {
-    return whisper_lang_auto_detect_with_state(ctx, ctx->state, offset_ms, n_threads, lang_probs);
-}
-
-int whisper_lang_auto_detect_candidates(
-        struct whisper_context * ctx,
-                           int   offset_ms,
-                           int   n_threads,
-                 const char * const * language_candidates,
-                           int   n_language_candidates,
-                         float * lang_probs) {
-    return whisper_lang_auto_detect_with_state_candidates(ctx, ctx->state, offset_ms, n_threads, language_candidates, n_language_candidates, lang_probs);
 }
 
 int whisper_model_n_vocab(struct whisper_context * ctx) {
@@ -6912,9 +6923,8 @@ int whisper_full_with_state(
 
         const auto lang_id = params.n_language_candidates > 0
             ? whisper_lang_auto_detect_with_state_candidates(
-                    ctx, state, 0, params.n_threads,
-                    params.language_candidates, params.n_language_candidates,
-                    probs.data())
+                ctx, state, 0, params.n_threads,
+                params.language_candidates, params.n_language_candidates, probs.data())
             : whisper_lang_auto_detect_with_state(ctx, state, 0, params.n_threads, probs.data());
         if (lang_id < 0) {
             WHISPER_LOG_ERROR("%s: failed to auto-detect language\n", __func__);

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4018,79 +4018,158 @@ const char * whisper_lang_str_full(int id) {
     return nullptr;
 }
 
-int whisper_lang_auto_detect_with_state(
+static int whisper_lang_candidates_to_ids(
+        const char * func_name,
+        const char * const * language_candidates,
+        int n_language_candidates,
+        std::vector<int> & lang_ids) {
+    lang_ids.clear();
+
+    if (n_language_candidates < 0) {
+        WHISPER_LOG_ERROR("%s: invalid candidate count %d\n", func_name, n_language_candidates);
+        return -4;
+    }
+
+    if (n_language_candidates == 0) {
+        for (const auto & kv : g_lang) {
+            lang_ids.push_back(kv.second.first);
+        }
+        return 0;
+    }
+
+    if (language_candidates == nullptr) {
+        WHISPER_LOG_ERROR("%s: language_candidates is null with n_language_candidates = %d\n", func_name, n_language_candidates);
+        return -4;
+    }
+
+    for (int i = 0; i < n_language_candidates; ++i) {
+        const char * candidate = language_candidates[i];
+        if (candidate == nullptr) {
+            WHISPER_LOG_ERROR("%s: language_candidates[%d] is null\n", func_name, i);
+            return -4;
+        }
+
+        const int lang_id = whisper_lang_id(candidate);
+        if (lang_id < 0) {
+            WHISPER_LOG_ERROR("%s: invalid language candidate '%s'\n", func_name, candidate);
+            return -4;
+        }
+
+        if (std::find(lang_ids.begin(), lang_ids.end(), lang_id) == lang_ids.end()) {
+            lang_ids.push_back(lang_id);
+        }
+    }
+
+    if (lang_ids.empty()) {
+        WHISPER_LOG_ERROR("%s: no valid language candidates provided\n", func_name);
+        return -4;
+    }
+
+    return 0;
+}
+
+static int whisper_lang_auto_detect_impl(
+        const char * func_name,
         struct whisper_context * ctx,
-          struct whisper_state * state,
-                           int   offset_ms,
-                           int   n_threads,
-                         float * lang_probs) {
+        struct whisper_state * state,
+        int offset_ms,
+        int n_threads,
+        const char * const * language_candidates,
+        int n_language_candidates,
+        float * lang_probs) {
+    if (n_language_candidates > 0 && !whisper_is_multilingual(ctx)) {
+        WHISPER_LOG_ERROR("%s: constrained auto-detect requires a multilingual model\n", func_name);
+        return -5;
+    }
+
+    std::vector<int> lang_ids;
+    const int candidates_result = whisper_lang_candidates_to_ids(func_name, language_candidates, n_language_candidates, lang_ids);
+    if (candidates_result != 0) {
+        return candidates_result;
+    }
+
     const int seek = offset_ms/10;
 
+    if (lang_probs) {
+        const int n_langs = whisper_lang_max_id() + 1;
+        std::fill(lang_probs, lang_probs + n_langs, 0.0f);
+    }
+
     if (seek < 0) {
-        WHISPER_LOG_ERROR("%s: offset %dms is before the start of the audio\n", __func__, offset_ms);
+        WHISPER_LOG_ERROR("%s: offset %dms is before the start of the audio\n", func_name, offset_ms);
         return -1;
     }
 
     if (seek >= state->mel.n_len_org) {
-        WHISPER_LOG_ERROR("%s: offset %dms is past the end of the audio (%dms)\n", __func__, offset_ms, state->mel.n_len_org*10);
+        WHISPER_LOG_ERROR("%s: offset %dms is past the end of the audio (%dms)\n", func_name, offset_ms, state->mel.n_len_org*10);
         return -2;
     }
 
-    // run the encoder
     if (whisper_encode_with_state(ctx, state, seek, n_threads) != 0) {
-        WHISPER_LOG_ERROR("%s: failed to encode\n", __func__);
+        WHISPER_LOG_ERROR("%s: failed to encode\n", func_name);
         return -6;
     }
 
     const std::vector<whisper_token> prompt = { whisper_token_sot(ctx) };
 
     if (whisper_decode_with_state(ctx, state, prompt.data(), prompt.size(), 0, n_threads) != 0) {
-        WHISPER_LOG_ERROR("%s: failed to decode\n", __func__);
+        WHISPER_LOG_ERROR("%s: failed to decode\n", func_name);
         return -7;
     }
 
     auto & logits_id = state->decoders[0].logits_id;
     logits_id.clear();
+    logits_id.reserve(lang_ids.size());
 
-    for (const auto & kv : g_lang) {
-        const auto token_lang = whisper_token_lang(ctx, kv.second.first);
-        logits_id.emplace_back(state->logits[token_lang], kv.second.first);
+    for (const int lang_id : lang_ids) {
+        const auto token_lang = whisper_token_lang(ctx, lang_id);
+        logits_id.emplace_back(state->logits[token_lang], lang_id);
     }
 
-    // sort descending
-    {
-        using pair_type = std::remove_reference<decltype(logits_id)>::type::value_type;
-        std::sort(logits_id.begin(), logits_id.end(), [](const pair_type & a, const pair_type & b) {
-            return a.first > b.first;
-        });
+    using pair_type = std::remove_reference<decltype(logits_id)>::type::value_type;
+    std::sort(logits_id.begin(), logits_id.end(), [](const pair_type & a, const pair_type & b) {
+        return a.first > b.first;
+    });
+
+    const auto max = logits_id[0].first;
+
+    double sum = 0.0f;
+    for (auto & kv : logits_id) {
+        kv.first = exp(kv.first - max);
+        sum += kv.first;
     }
 
-    // softmax
-    {
-        const auto max = logits_id[0].first;
-
-        double sum = 0.0f;
-        for (auto & kv : logits_id) {
-            kv.first = exp(kv.first - max);
-            sum += kv.first;
-        }
-
-        for (auto & kv : logits_id) {
-            kv.first /= sum;
-        }
+    for (auto & kv : logits_id) {
+        kv.first /= sum;
     }
 
-    {
-        for (const auto & prob : logits_id) {
-            if (lang_probs) {
-                lang_probs[prob.second] = prob.first;
-            }
-
-            //printf("%s: lang %2d (%3s): %f\n", __func__, prob.second, whisper_lang_str(prob.second), prob.first);
+    for (const auto & prob : logits_id) {
+        if (lang_probs) {
+            lang_probs[prob.second] = prob.first;
         }
     }
 
     return logits_id[0].second;
+}
+
+int whisper_lang_auto_detect_with_state(
+        struct whisper_context * ctx,
+          struct whisper_state * state,
+                           int   offset_ms,
+                           int   n_threads,
+                         float * lang_probs) {
+    return whisper_lang_auto_detect_impl(__func__, ctx, state, offset_ms, n_threads, nullptr, 0, lang_probs);
+}
+
+int whisper_lang_auto_detect_with_state_candidates(
+        struct whisper_context * ctx,
+          struct whisper_state * state,
+                           int   offset_ms,
+                           int   n_threads,
+                 const char * const * language_candidates,
+                           int   n_language_candidates,
+                         float * lang_probs) {
+    return whisper_lang_auto_detect_impl(__func__, ctx, state, offset_ms, n_threads, language_candidates, n_language_candidates, lang_probs);
 }
 
 int whisper_lang_auto_detect(
@@ -4099,6 +4178,16 @@ int whisper_lang_auto_detect(
                            int   n_threads,
                          float * lang_probs) {
     return whisper_lang_auto_detect_with_state(ctx, ctx->state, offset_ms, n_threads, lang_probs);
+}
+
+int whisper_lang_auto_detect_candidates(
+        struct whisper_context * ctx,
+                           int   offset_ms,
+                           int   n_threads,
+                 const char * const * language_candidates,
+                           int   n_language_candidates,
+                         float * lang_probs) {
+    return whisper_lang_auto_detect_with_state_candidates(ctx, ctx->state, offset_ms, n_threads, language_candidates, n_language_candidates, lang_probs);
 }
 
 int whisper_model_n_vocab(struct whisper_context * ctx) {
@@ -5951,6 +6040,8 @@ struct whisper_full_params whisper_full_default_params(enum whisper_sampling_str
 
         /*.language          =*/ "en",
         /*.detect_language   =*/ false,
+        /*.language_candidates =*/ nullptr,
+        /*.n_language_candidates =*/ 0,
 
         /*.suppress_blank    =*/ true,
         /*.suppress_nst      =*/ false,
@@ -6819,7 +6910,12 @@ int whisper_full_with_state(
     if (params.language == nullptr || strlen(params.language) == 0 || strcmp(params.language, "auto") == 0 || params.detect_language) {
         std::vector<float> probs(whisper_lang_max_id() + 1, 0.0f);
 
-        const auto lang_id = whisper_lang_auto_detect_with_state(ctx, state, 0, params.n_threads, probs.data());
+        const auto lang_id = params.n_language_candidates > 0
+            ? whisper_lang_auto_detect_with_state_candidates(
+                    ctx, state, 0, params.n_threads,
+                    params.language_candidates, params.n_language_candidates,
+                    probs.data())
+            : whisper_lang_auto_detect_with_state(ctx, state, 0, params.n_threads, probs.data());
         if (lang_id < 0) {
             WHISPER_LOG_ERROR("%s: failed to auto-detect language\n", __func__);
             return -3;

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3996,33 +3996,11 @@ int whisper_lang_id(const char * lang) {
     return g_lang.at(lang).first;
 }
 
-const char * whisper_lang_str(int id) {
-    for (const auto & kv : g_lang) {
-        if (kv.second.first == id) {
-            return kv.first.c_str();
-        }
-    }
-
-    WHISPER_LOG_ERROR("%s: unknown language id %d\n", __func__, id);
-    return nullptr;
-}
-
-const char * whisper_lang_str_full(int id) {
-   for (const auto & kv : g_lang) {
-        if (kv.second.first == id) {
-            return kv.second.second.c_str();
-        }
-    }
-
-    WHISPER_LOG_ERROR("%s: unknown language id %d\n", __func__, id);
-    return nullptr;
-}
-
 int whisper_lang_candidates_to_ids(
-        const char * func_name,
-        const char * const * language_candidates,
-        int n_language_candidates,
-        std::vector<int> & lang_ids) {
+                    const char * func_name,
+                    const char * const * language_candidates,
+                           int   n_language_candidates,
+              std::vector<int> & lang_ids) {
     lang_ids.clear();
 
     if (n_language_candidates < 0) {
@@ -4068,6 +4046,28 @@ int whisper_lang_candidates_to_ids(
     return 0;
 }
 
+const char * whisper_lang_str(int id) {
+    for (const auto & kv : g_lang) {
+        if (kv.second.first == id) {
+            return kv.first.c_str();
+        }
+    }
+
+    WHISPER_LOG_ERROR("%s: unknown language id %d\n", __func__, id);
+    return nullptr;
+}
+
+const char * whisper_lang_str_full(int id) {
+   for (const auto & kv : g_lang) {
+        if (kv.second.first == id) {
+            return kv.second.second.c_str();
+        }
+    }
+
+    WHISPER_LOG_ERROR("%s: unknown language id %d\n", __func__, id);
+    return nullptr;
+}
+
 static int whisper_lang_auto_detect_impl(
                     const char * func_name,
         struct whisper_context * ctx,
@@ -4077,11 +4077,6 @@ static int whisper_lang_auto_detect_impl(
             const char * const * language_candidates,
                            int   n_language_candidates,
                          float * lang_probs) {
-    if (n_language_candidates > 0 && !whisper_is_multilingual(ctx)) {
-        WHISPER_LOG_ERROR("%s: constrained auto-detect requires a multilingual model\n", func_name);
-        return -5;
-    }
-
     std::vector<int> lang_ids;
     const int candidates_result = whisper_lang_candidates_to_ids(func_name, language_candidates, n_language_candidates, lang_ids);
     if (candidates_result != 0) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,24 @@ add_test(NAME ${TEST_TARGET}
     -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
 set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "large")
 
+set(TEST_TARGET test-whisper-cli-detect-language-candidates)
+add_test(NAME ${TEST_TARGET}
+    COMMAND $<TARGET_FILE:whisper-cli>
+    -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.bin
+    -ng -dl --language-candidates en,fr
+    -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
+set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "base;gh")
+
+set(TEST_TARGET test-whisper-cli-detect-language-candidates-nonmultilingual)
+add_test(NAME ${TEST_TARGET}
+    COMMAND $<TARGET_FILE:whisper-cli>
+    -m ${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.en.bin
+    -ng -dl --language-candidates en,fr
+    -f ${PROJECT_SOURCE_DIR}/samples/jfk.wav)
+set_tests_properties(${TEST_TARGET} PROPERTIES
+    LABELS "base;en"
+    WILL_FAIL TRUE)
+
 if (WHISPER_FFMPEG)
     set(TEST_TARGET test-whisper-cli-tiny-mp3)
     # Check with reviewers: any way to check the output transcription via ctest (diff, ...)?
@@ -110,3 +128,14 @@ target_compile_definitions(${VAD_TEST} PRIVATE
     SAMPLE_PATH="${PROJECT_SOURCE_DIR}/samples/jfk.wav")
 add_test(NAME ${VAD_TEST} COMMAND ${VAD_TEST})
 set_tests_properties(${VAD_TEST} PROPERTIES LABELS "base;en")
+
+set(LANG_TEST test-lang-auto-detect)
+add_executable(${LANG_TEST} ${LANG_TEST}.cpp)
+target_include_directories(${LANG_TEST} PRIVATE ../include ../ggml/include ../examples)
+target_link_libraries(${LANG_TEST} PRIVATE common)
+target_compile_definitions(${LANG_TEST} PRIVATE
+    WHISPER_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.bin"
+    WHISPER_MODEL_EN_PATH="${PROJECT_SOURCE_DIR}/models/for-tests-ggml-base.en.bin"
+    SAMPLE_PATH="${PROJECT_SOURCE_DIR}/samples/jfk.wav")
+add_test(NAME ${LANG_TEST} COMMAND ${LANG_TEST})
+set_tests_properties(${LANG_TEST} PROPERTIES LABELS "base;en;unit")

--- a/tests/test-lang-auto-detect.cpp
+++ b/tests/test-lang-auto-detect.cpp
@@ -1,0 +1,66 @@
+#include "whisper.h"
+#include "common-whisper.h"
+
+#include <cassert>
+#include <cstring>
+#include <vector>
+
+static void assert_only_candidates_have_probability(const std::vector<float> & probs, int lang_a, int lang_b) {
+    for (int i = 0; i < (int) probs.size(); ++i) {
+        if (i == lang_a || i == lang_b) {
+            assert(probs[i] >= 0.0f);
+        } else {
+            assert(probs[i] == 0.0f);
+        }
+    }
+}
+
+int main() {
+    std::vector<float> pcmf32;
+    std::vector<std::vector<float>> pcmf32s;
+    assert(read_audio_data(SAMPLE_PATH, pcmf32, pcmf32s, false));
+
+    struct whisper_context_params cparams = whisper_context_default_params();
+    cparams.use_gpu = false;
+
+    struct whisper_context * wctx = whisper_init_from_file_with_params(WHISPER_MODEL_PATH, cparams);
+    assert(wctx != nullptr);
+    assert(whisper_is_multilingual(wctx));
+    assert(whisper_pcm_to_mel(wctx, pcmf32.data(), pcmf32.size(), 1) == 0);
+
+    const char * candidates[] = {"fr", "en", "en"};
+    std::vector<float> probs(whisper_lang_max_id() + 1, -1.0f);
+
+    const int lang_id = whisper_lang_auto_detect_candidates(wctx, 0, 1, candidates, 3, probs.data());
+    assert(lang_id == whisper_lang_id("en"));
+    assert(probs[whisper_lang_id("en")] > 0.0f);
+    assert(probs[whisper_lang_id("fr")] > 0.0f);
+    assert_only_candidates_have_probability(probs, whisper_lang_id("en"), whisper_lang_id("fr"));
+
+    const char * invalid_candidates[] = {"zz"};
+    assert(whisper_lang_auto_detect_candidates(wctx, 0, 1, invalid_candidates, 1, nullptr) == -4);
+
+    const char * null_candidate = nullptr;
+    assert(whisper_lang_auto_detect_candidates(wctx, 0, 1, &null_candidate, 1, nullptr) == -4);
+
+    struct whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    wparams.language = "auto";
+    wparams.detect_language = true;
+    wparams.language_candidates = candidates;
+    wparams.n_language_candidates = 3;
+
+    assert(whisper_full(wctx, wparams, pcmf32.data(), pcmf32.size()) == 0);
+    assert(whisper_full_lang_id(wctx) == whisper_lang_id("en"));
+
+    whisper_free(wctx);
+
+    struct whisper_context * wctx_en = whisper_init_from_file_with_params(WHISPER_MODEL_EN_PATH, cparams);
+    assert(wctx_en != nullptr);
+    assert(!whisper_is_multilingual(wctx_en));
+    assert(whisper_pcm_to_mel(wctx_en, pcmf32.data(), pcmf32.size(), 1) == 0);
+    assert(whisper_lang_auto_detect_candidates(wctx_en, 0, 1, candidates, 2, nullptr) == -5);
+
+    whisper_free(wctx_en);
+
+    return 0;
+}


### PR DESCRIPTION
In my case, the audio is known to contain only a subset of languages. However, when I use auto-detect, it sometimes selects a similar or unrelated language. For example, Indonesian audio may be detected as Malay.

This PR constrains auto-detect to a user-provided set of candidate languages.

- Related issue: #3334

Test:

```
% cmake --build build --target test-lang-auto-detect && \
    ctest -R ^test-lang-auto-detect$ --test-dir build --output-on-failure -VV
```

<details>
<summary>
whisper-cli output:

```
% ./build/bin/whisper-cli -m ./models/ggml-base.bin -f samples/jfk.wav \
    --language auto --language-candidates en,es
```
</summary>

```
whisper_init_from_file_with_params_no_state: loading model from './models/ggml-base.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
ggml_metal_device_init: tensor API disabled for pre-M5 and pre-A19 devices
ggml_metal_library_init: using embedded metal library
ggml_metal_library_init: loaded in 0.011 sec
ggml_metal_rsets_init: creating a residency set collection (keep_alive = 180 s)
ggml_metal_device_init: GPU name:   MTL0 (Apple M3 Max)
ggml_metal_device_init: GPU family: MTLGPUFamilyApple9  (1009)
ggml_metal_device_init: GPU family: MTLGPUFamilyCommon3 (3003)
ggml_metal_device_init: GPU family: MTLGPUFamilyMetal4  (5002)
ggml_metal_device_init: simdgroup reduction   = true
ggml_metal_device_init: simdgroup matrix mul. = true
ggml_metal_device_init: has unified memory    = true
ggml_metal_device_init: has bfloat            = true
ggml_metal_device_init: has tensor            = false
ggml_metal_device_init: use residency sets    = true
ggml_metal_device_init: use shared buffers    = true
ggml_metal_device_init: recommendedMaxWorkingSetSize  = 30150.67 MB
whisper_init_with_params_no_state: devices    = 3
whisper_init_with_params_no_state: backends   = 3
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 512
whisper_model_load: n_audio_head  = 8
whisper_model_load: n_audio_layer = 6
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 512
whisper_model_load: n_text_head   = 8
whisper_model_load: n_text_layer  = 6
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 2 (base)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:         MTL0 total size =   147.37 MB
whisper_model_load: model size    =  147.37 MB
whisper_backend_init_gpu: device 0: MTL0 (type: 1)
whisper_backend_init_gpu: found GPU device 0: MTL0 (type: 1, cnt: 0)
whisper_backend_init_gpu: using MTL0 backend
ggml_metal_init: allocating
ggml_metal_init: found device: Apple M3 Max
ggml_metal_init: picking default device: Apple M3 Max
ggml_metal_init: use fusion         = true
ggml_metal_init: use concurrency    = true
ggml_metal_init: use graph optimize = true
whisper_backend_init: using BLAS backend
whisper_init_state: kv self size  =    6.29 MB
whisper_init_state: kv cross size =   18.87 MB
whisper_init_state: kv pad  size  =    3.15 MB
whisper_init_state: compute buffer (conv)   =   17.24 MB
whisper_init_state: compute buffer (encode) =   26.31 MB
whisper_init_state: compute buffer (cross)  =   38.45 MB
whisper_init_state: compute buffer (decode) =   97.29 MB

system_info: n_threads = 4 / 14 | WHISPER : COREML = 0 | OPENVINO = 0 | MTL : EMBED_LIBRARY = 1 | CPU : NEON = 1 | ARM_FMA = 1 | FP16_VA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | ACCELERATE = 1 | OPENMP = 1 | REPACK = 1 | 

main: processing 'samples/jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = auto, task = transcribe, timestamps = 1 ...
main: constrained auto-detect candidates = en,es

whisper_full_with_state: auto-detected language: en (p = 0.995665)

[00:00:00.000 --> 00:00:10.500]   And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =    66.74 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     3.52 ms
whisper_print_timings:   sample time =    22.08 ms /   137 runs (     0.16 ms per run)
whisper_print_timings:   encode time =    56.77 ms /     2 runs (    28.39 ms per run)
whisper_print_timings:   decode time =     4.58 ms /     3 runs (     1.53 ms per run)
whisper_print_timings:   batchd time =    46.38 ms /   133 runs (     0.35 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =   210.29 ms
ggml_metal_free: deallocating
```

</details>