### PR TITLE
[AMD] Add AMD ROCm/HIP GPU build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ High-performance inference of [OpenAI's Whisper](https://github.com/openai/whisp
 - [Vulkan support](#vulkan-gpu-support)
 - Support for CPU-only inference
 - [Efficient GPU support for NVIDIA](#nvidia-gpu-support)
+- [AMD ROCm GPU support](#amd-rocm-gpu-support)
 - [OpenVINO Support](#openvino-support)
 - [Ascend NPU Support](#ascend-npu-support)
 - [Moore Threads GPU Support](#moore-threads-gpu-support)
@@ -339,6 +340,27 @@ Now build `whisper.cpp` with Vulkan support:
 cmake -B build -DGGML_VULKAN=1
 cmake --build build -j --config Release
 ```
+
+## AMD ROCm GPU support
+
+With AMD GPUs the processing can be accelerated via HIP/ROCm.
+First, make sure you have installed [ROCm](https://rocm.docs.amd.com/en/latest/).
+
+Now build `whisper.cpp` with HIP support:
+
+```
+cmake -B build -DGGML_HIP=1 -DAMDGPU_TARGETS="gfx1201"
+cmake --build build -j --config Release
+```
+
+Replace `gfx1201` with your GPU architecture. You can find it with:
+
+```
+rocminfo | grep "gfx"
+```
+
+Common architectures: `gfx1100` (RX 7900 XTX), `gfx1101` (RX 7800 XT), `gfx1201` (RX 9070 XT).
+For multiple GPUs with different architectures: `-DAMDGPU_TARGETS="gfx1100;gfx1201"`.
 
 ## BLAS CPU support via OpenBLAS
 


### PR DESCRIPTION
## Summary

Add AMD ROCm/HIP GPU build instructions to the README. The project already supports HIP via the shared ggml backend (`GGML_HIP=1`), but the README only documents NVIDIA CUDA, Vulkan, Ascend NPU, and Moore Threads backends.

## Test environment

- GPU: AMD Radeon R9700 Pro (gfx1201, RDNA 4), 32 GB VRAM
- ROCm: 7.2.3, HIP: 7.2.53211
- Container: `rocm/pytorch:rocm7.2.3_ubuntu24.04_py3.12_pytorch_release_2.9.1`

## Test

```bash
git clone --depth 1 https://github.com/ggml-org/whisper.cpp.git
cd whisper.cpp
cmake -B build -DGGML_HIP=1 -DAMDGPU_TARGETS="gfx1201" -DCMAKE_BUILD_TYPE=Release
cmake --build build -j$(nproc)
./models/download-ggml-model.sh tiny.en

$ ./build/bin/whisper-cli -m models/ggml-tiny.en.bin -f samples/jfk.wav --no-timestamps

whisper_init_from_file_with_params_no_state: loading model from 'models/ggml-tiny.en.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
ggml_cuda_init: found 1 ROCm devices (Total VRAM: 30576 MiB):
  Device 0: AMD Radeon Graphics, gfx1201 (0x1201), VMM: no, Wave Size: 32, VRAM: 30576 MiB
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51864
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 384
whisper_model_load: n_audio_head  = 6
whisper_model_load: n_audio_layer = 4
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 384
whisper_model_load: n_text_head   = 6
whisper_model_load: n_text_layer  = 4
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: type          = 1 (tiny)
whisper_model_load:        ROCm0 total size =    77.11 MB
whisper_backend_init_gpu: using ROCm0 backend
whisper_init_state: kv self size  =    3.15 MB
whisper_init_state: kv cross size =    9.44 MB
whisper_init_state: kv pad  size  =    2.36 MB
whisper_init_state: compute buffer (conv)   =   14.17 MB
whisper_init_state: compute buffer (encode) =   17.72 MB
whisper_init_state: compute buffer (cross)  =    3.89 MB
whisper_init_state: compute buffer (decode) =   96.83 MB

system_info: n_threads = 4 / 192 | WHISPER : COREML = 0 | OPENVINO = 0 | ROCm : NO_VMM = 1 | PEER_MAX_BATCH_SIZE = 128 | CPU : SSE3 = 1 | SSSE3 = 1 | AVX = 1 | AVX_VNNI = 1 | AVX2 = 1 | F16C = 1 | FMA = 1 | BMI2 = 1 | AVX512 = 1 | AVX512_VBMI = 1 | AVX512_VNNI = 1 | AVX512_BF16 = 1 | OPENMP = 1 | REPACK = 1 |

main: processing 'samples/jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = en, task = transcribe, timestamps = 0 ...


 And so my fellow Americans ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =    73.18 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     8.52 ms
whisper_print_timings:   sample time =    29.42 ms /   125 runs (     0.24 ms per run)
whisper_print_timings:   encode time =    36.29 ms /     1 runs (    36.29 ms per run)
whisper_print_timings:   decode time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:   batchd time =    49.42 ms /   122 runs (     0.41 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =   205.72 ms
```