### PR TITLE
ggml-cuda : update cudaLaunchKernelEx check to 12.0

### DIFF
--- a/ggml/src/ggml-cuda/common.cuh
+++ b/ggml/src/ggml-cuda/common.cuh
@@ -110,11 +110,11 @@
 #    define GGML_CUDA_USE_CUB
 #endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11070
 
-// PDL host-side support (cudaLaunchKernelEx) requires CUDART >= 11.8 and excludes HIP/MUSA.
+// PDL host-side support (cudaLaunchKernelEx) requires CUDART >= 12.0 and excludes HIP/MUSA.
 // __CUDA_ARCH__  is undefined in host passes; GPU arch check happens in device-side code.
-#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11080
+#if !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12000
 #    define GGML_CUDA_USE_PDL
-#endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 11080
+#endif  // !defined(GGML_USE_HIP) && !defined(GGML_USE_MUSA) && CUDART_VERSION >= 12000
 
 static __device__ __forceinline__ void ggml_cuda_pdl_sync() {
 #if defined(GGML_CUDA_USE_PDL) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= GGML_CUDA_CC_HOPPER


### PR DESCRIPTION
This commit updates the CUDART check to 12.8 instead of the current 11.8.

The motivation for this is that currently whisper.cpp CI is failing when building 11.8.0, with the following error:
```console
ggml\src\ggml-cuda\common.cuh(1568): error: identifier "cudaLaunchKernelEx" is undefined
```
It looks like cudaLaunchKernelEx was introduced in CUDA 12.0 which would therefor be the reason for this failure.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/26493577141/job/78016424109?pr=3735#step:11:879