### PR TITLE
ci : set GGML_NATIVE=OFF for bindings-java

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -641,6 +641,7 @@ jobs:
           -DBUILD_SHARED_LIBS=ON
           -DWHISPER_SDL2=${{ matrix.sdl2 }}
           -DGGML_NATIVE=OFF
+          -DGGML_BMI2=OFF
 
       - name: Build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -640,6 +640,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.build }}
           -DBUILD_SHARED_LIBS=ON
           -DWHISPER_SDL2=${{ matrix.sdl2 }}
+          -DGGML_NATIVE=OFF
 
       - name: Build
         run: |


### PR DESCRIPTION
This commit attempts to address an issue with the bindings-java job which is currently failing.

I've not been able to reproduce this locally my windows machine and I suspect that what might be happning is that windows job compiles on a runner where it has different CPU features, for example AVX512 and when this dll is used on a different runner that does not have that feature it will crash.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/26496174929/job/78059073255?pr=3829