### PR TITLE
ci : renable arm64 docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,27 +9,24 @@ jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
 
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.config.runs_on }}
     env:
       COMMIT_SHA: ${{ github.sha }}
     strategy:
       fail-fast: false
       matrix:
         config:
-          - { tag: "main", dockerfile: ".devops/main.Dockerfile", platform: "linux/amd64" }
-          - { tag: "main-musa", dockerfile: ".devops/main-musa.Dockerfile", platform: "linux/amd64" }
-          - { tag: "main-intel", dockerfile: ".devops/main-intel.Dockerfile", platform: "linux/amd64" }
-          - { tag: "main-cuda", dockerfile: ".devops/main-cuda.Dockerfile", platform: "linux/amd64" }
-          - { tag: "main-vulkan", dockerfile: ".devops/main-vulkan.Dockerfile", platform: "linux/amd64" }
+          - { tag: "main",              dockerfile: ".devops/main.Dockerfile",        platform: "linux/amd64", runs_on: "ubuntu-24.04"     }
+          - { tag: "main-arm64",        dockerfile: ".devops/main.Dockerfile",        platform: "linux/arm64", runs_on: "ubuntu-24.04-arm" }
+          - { tag: "main-musa",         dockerfile: ".devops/main-musa.Dockerfile",   platform: "linux/amd64", runs_on: "ubuntu-24.04"     }
+          - { tag: "main-intel",        dockerfile: ".devops/main-intel.Dockerfile",  platform: "linux/amd64", runs_on: "ubuntu-24.04"     }
+          - { tag: "main-cuda",         dockerfile: ".devops/main-cuda.Dockerfile",   platform: "linux/amd64", runs_on: "ubuntu-24.04"     }
+          - { tag: "main-vulkan",       dockerfile: ".devops/main-vulkan.Dockerfile", platform: "linux/amd64", runs_on: "ubuntu-24.04"     }
+          - { tag: "main-vulkan-arm64", dockerfile: ".devops/main-vulkan.Dockerfile", platform: "linux/arm64", runs_on: "ubuntu-24.04-arm" }
 
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This commit re-enables the arm64 docker images builds which were removed in Commit 9366544991bfee59c927e7c23b1861c6c762e708 ("ci : fix arm builds"). It also uses ubuntu-24.04-arm as the runner which enables us to avoid QEMU.

Resolves: https://github.com/ggml-org/whisper.cpp/issues/2859


----

Running this on my [fork](https://github.com/danbev/whisper.cpp/actions/runs/26562654621/job/78249234437) (disabling publishing of the images).