### PR TITLE
ci : add on push/pull_request paths ruby job

### DIFF
--- a/.github/workflows/bindings-ruby.yml
+++ b/.github/workflows/bindings-ruby.yml
@@ -4,8 +4,15 @@ on:
   push:
     branches:
       - master
+    paths:
+      - bindings/ruby/**
+      - include/whisper.h
+
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - bindings/ruby/**
+      - include/whisper.h
 
 jobs:
   ubuntu-22:

--- a/.github/workflows/bindings-ruby.yml
+++ b/.github/workflows/bindings-ruby.yml
@@ -7,12 +7,16 @@ on:
     paths:
       - bindings/ruby/**
       - include/whisper.h
+      - examples/common-whisper.h
+      - ggml/include/ggml.h
 
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - bindings/ruby/**
       - include/whisper.h
+      - examples/common-whisper.h
+      - ggml/include/ggml.h
 
 jobs:
   ubuntu-22:


### PR DESCRIPTION
This commit adds paths to bindings-ruby to only build if changes where made to bindings/ruby or to include/whisper.h.