### PR TITLE
ci : fix path to whisper.h in examples.yml [no ci]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths-ignore:
-      - 'bindings/ruby/**' # handled by bindings-ruby.yml
-      - 'bindings/go/**'   # handled by bindings-go.yml
+      - 'bindings/ruby/**'        # handled by bindings-ruby.yml
+      - 'bindings/go/**'          # handled by bindings-go.yml
+      - 'examples/addon.node/**'  # handled by examples.yml
   workflow_dispatch:
     inputs:
       create_release:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,13 +1,15 @@
 name: Examples Tests
 on:
   push:
+    branches:
+      - master
     paths:
       - examples/addon.node/**
-      - whisper.h
+      - include/whisper.h
   pull_request:
     paths:
       - examples/addon.node/**
-      - whisper.h
+      - include/whisper.h
 
 jobs:
   addon_node-ubuntu-22:


### PR DESCRIPTION
This commit updates the include path to whisper.h and also ensures that this is only built on pushes to master.