### PR TITLE
ci : use emscripten-core and pin version

### DIFF
--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: emscripten-core/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
 
       - name: Verify
         run: emcc -v

--- a/.github/workflows/deploy-examples-wasm.yml
+++ b/.github/workflows/deploy-examples-wasm.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Setup emsdk
-        uses: mymindstorm/setup-emsdk@v14
+        uses: emscripten-core/setup-emsdk@6ab9eb1bda2574c4ddb79809fc9247783eaf9021 # v14
 
       - name: Build WASM Examples
         # Enable for real build later in whisper.cpp


### PR DESCRIPTION
This commit updates the setup emscripten sdk jobs to use emscripten-core instead of mymindstorm and also pins the commit sha for the version instead of using a version tag.