### PR TITLE
ci:  build-windows action slimming

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -38,8 +38,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { sys: UCRT64,  env: ucrt-x86_64,  build: Release }
-          - { sys: CLANG64, env: clang-x86_64, build: Release }
+          - { sys: UCRT64,  env: ucrt-x86_64,  compiler: gcc,   build: Release }
+          - { sys: CLANG64, env: clang-x86_64, compiler: clang, build: Release }
 
     steps:
       - name: Clone
@@ -51,7 +51,7 @@ jobs:
           update: true
           msystem: ${{matrix.sys}}
           install: >-
-            mingw-w64-${{matrix.env}}-toolchain
+            mingw-w64-${{matrix.env}}-${{matrix.compiler}}
             mingw-w64-${{matrix.env}}-cmake
             mingw-w64-${{matrix.env}}-SDL2
             mingw-w64-${{matrix.env}}-openblas

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -51,8 +51,6 @@ jobs:
           update: true
           msystem: ${{matrix.sys}}
           install: >-
-            base-devel
-            git
             mingw-w64-${{matrix.env}}-toolchain
             mingw-w64-${{matrix.env}}-cmake
             mingw-w64-${{matrix.env}}-SDL2


### PR DESCRIPTION
This PR attempt to slim down the dependencies for windows-msys2 jobs.

This was run successfully on my [fork](https://github.com/danbev/whisper.cpp/actions/runs/26954105110). I first removed the cache entries before running. 

After running these were the [cache sizes](https://github.com/danbev/whisper.cpp/actions/caches):
* msys2-pkgs-upd:true-conf:d01fbccc-files:97266226a09f4601e907691590a43b6b9c4227bbe7cfba140a0a71d8d064ac8b
200 MB 
* msys2-pkgs-upd:true-conf:44b112b6-files:9cb2b11cc50b9d5fc9afbde28a1f2b1f1885458f56b2daad9547fd7d5b43ae5b
140 MB

We need to manually delete the existing entries for this. I've not done so yet.