### PR TITLE
coreml : fix --quantize crash and --optimize-ane label for mlprogram format

### DIFF
--- a/models/convert-whisper-to-coreml.py
+++ b/models/convert-whisper-to-coreml.py
@@ -8,9 +8,18 @@ from torch import nn
 from typing import Dict
 from typing import Optional
 from ane_transformers.reference.layer_norm import LayerNormANE as LayerNormANEBase
-from coremltools.models.neural_network.quantization_utils import quantize_weights
 from whisper.model import Whisper, AudioEncoder, TextDecoder, ResidualAttentionBlock, MultiHeadAttention, ModelDimensions
 from whisper import load_model
+
+
+def _str_to_bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ("true", "1", "yes"):
+        return True
+    if v.lower() in ("false", "0", "no"):
+        return False
+    raise argparse.ArgumentTypeError(f"boolean value expected, got '{v}'")
 
 # Disable PyTorch Scaled Dot-Product Attention (SDPA) to avoid compatibility issues.
 # The Whisper implementation expects a specific behavior from
@@ -258,10 +267,8 @@ def convert_encoder(hparams, model, quantize=False):
         inputs=[ct.TensorType(name="logmel_data", shape=input_shape)],
         outputs=[ct.TensorType(name="output")],
         compute_units=ct.ComputeUnit.ALL,
+        compute_precision=ct.precision.FLOAT16 if quantize else ct.precision.FLOAT32,
     )
-
-    if quantize:
-        model = quantize_weights(model, nbits=16)
 
     return model
 
@@ -283,10 +290,8 @@ def convert_decoder(hparams, model, quantize=False):
             ct.TensorType(name="token_data", shape=tokens_shape, dtype=int),
             ct.TensorType(name="audio_data", shape=audio_shape)
         ],
+        compute_precision=ct.precision.FLOAT16 if quantize else ct.precision.FLOAT32,
     )
-
-    if quantize:
-        model = quantize_weights(model, nbits=16)
 
     return model
 
@@ -294,9 +299,9 @@ def convert_decoder(hparams, model, quantize=False):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--model", type=str, help="model to convert (e.g. tiny, tiny.en, base, base.en, small, small.en, medium, medium.en, large-v1, large-v2, large-v3, large-v3-turbo)", required=True)
-    parser.add_argument("--encoder-only", type=bool, help="only convert encoder", default=False)
-    parser.add_argument("--quantize",     type=bool, help="quantize weights to F16", default=False)
-    parser.add_argument("--optimize-ane", type=bool, help="optimize for ANE execution (currently broken)", default=False)
+    parser.add_argument("--encoder-only", type=_str_to_bool, help="only convert encoder", default=False)
+    parser.add_argument("--quantize",     type=_str_to_bool, help="quantize weights to F16", default=False)
+    parser.add_argument("--optimize-ane", type=_str_to_bool, help="optimize for ANE execution", default=False)
     args = parser.parse_args()
 
     if args.model not in ["tiny", "tiny.en", "base", "base.en", "small", "small.en", "small.en-tdrz", "medium", "medium.en", "large-v1", "large-v2", "large-v3", "large-v3-turbo"]:


### PR DESCRIPTION
## What broke

Commit 8b92060 switched `ct.convert()` from `neuralnetwork` to `mlprogram`, but two things were not updated:

**1. `--quantize` crashes.**
`quantize_weights` from `coremltools.models.neural_network.quantization_utils` only works with the legacy `neuralnetwork` format. With `mlprogram` it raises:

```
Exception: MLModel of type mlProgram cannot be loaded just from the model spec
object. It also needs the path to the weights file.
```

**2. `--optimize-ane` was labeled "currently broken".**
The ANE conversion path (`WhisperANE`, `AudioEncoderANE`, `LayerNormANE`) converts and loads without error under PyTorch 2.x and coremltools 9.x. It was likely labeled broken because the crash from bug 1 was triggered when both flags were combined.

**3. `type=bool` in argparse silently misparses `--flag False`.**
`bool("False") == True`, so `--encoder-only False` was treated as `True`. Added a `_str_to_bool` helper that handles both string and native-bool forms; the old `--flag True` call syntax still works.

## Fix

- Replace `quantize_weights(model, nbits=16)` with `compute_precision=ct.precision.FLOAT16` passed to `ct.convert()`. This matches the original intent (F16 storage) without changing the quantization scheme or touching model weights after conversion.
- Switch all three boolean flags from `type=bool` to `type=_str_to_bool`. Existing scripts using `--encoder-only True` keep working; `--encoder-only False` now correctly disables the flag.
- Remove the "currently broken" label from `--optimize-ane`.

## Verification

Tested on Apple M3 Ultra, macOS 15.5, coremltools 9.0, PyTorch 2.12.

Before (crashes):
```
$ python models/convert-whisper-to-coreml.py --model large-v3-turbo --encoder-only True --quantize True
Exception: MLModel of type mlProgram cannot be loaded just from the model spec object...
```

After (all combinations succeed):
```
$ python models/convert-whisper-to-coreml.py --model large-v3-turbo --encoder-only True --quantize True
done converting

$ python models/convert-whisper-to-coreml.py --model large-v3-turbo --encoder-only True --optimize-ane True
done converting

$ python models/convert-whisper-to-coreml.py --model large-v3-turbo --encoder-only True --optimize-ane True --quantize True
done converting
```

Benchmark on M3 Ultra (large-v3-turbo, `whisper-bench -w 0`):

| variant | encode | decode/run | total |
|---|---|---|---|
| Metal only | 173 ms | 1.36 ms | 756 ms |
| CoreML (no ANE opt) | 636 ms | 1.36 ms | 1216 ms |
| CoreML + ANE opt | 469 ms | 1.36 ms | 1051 ms |

Metal is faster on M3 Ultra; CoreML routes to the GPU through its overhead layer rather than the ANE on this chip. The ANE-optimized model is ~26% faster on the encoder than the plain CoreML model. Results on iPhone/iPad with a dedicated ANE may differ.