### PR TITLE
Fix pkgconfig configuration (Nix build failure)

### DIFF
--- a/cmake/parakeet.pc.in
+++ b/cmake/parakeet.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: parakeet
 Description: Port of NVIDIA's Parakeet model in C/C++

--- a/cmake/whisper.pc.in
+++ b/cmake/whisper.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/include
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: whisper
 Description: Port of OpenAI's Whisper model in C/C++


### PR DESCRIPTION
@danbev, @waptaff: PR #3693 leads to a build failure on Nix, where `@CMAKE_INSTALL_LIBDIR@` is an absolute instead of a relative path. This leads to a malformed .pc file containing `//`.

For a correct, portable solution, `@CMAKE_INSTALL_FULL_LIBDIR@` should be used instead.

This may impact other installations as well, and it would be better to fix this upstream rather than downstream: https://github.com/NixOS/nixpkgs/pull/532522