### PR TITLE
include parakeet in build-xcframework.sh

### DIFF
--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -115,6 +115,7 @@ setup_framework_structure() {
 
     # Copy all required headers (common for all platforms)
     cp include/whisper.h           ${header_path}
+    cp include/parakeet.h          ${header_path}
     cp ggml/include/ggml.h         ${header_path}
     cp ggml/include/ggml-alloc.h   ${header_path}
     cp ggml/include/ggml-backend.h ${header_path}
@@ -127,6 +128,7 @@ setup_framework_structure() {
     cat > ${module_path}module.modulemap << EOF
 framework module whisper {
     header "whisper.h"
+    header "parakeet.h"
     header "ggml.h"
     header "ggml-alloc.h"
     header "ggml-backend.h"
@@ -245,6 +247,7 @@ combine_static_libraries() {
 
     local libs=(
         "${base_dir}/${build_dir}/src/${release_dir}/libwhisper.a"
+        "${base_dir}/${build_dir}/src/${release_dir}/libparakeet.a"
         "${base_dir}/${build_dir}/ggml/src/${release_dir}/libggml.a"
         "${base_dir}/${build_dir}/ggml/src/${release_dir}/libggml-base.a"
         "${base_dir}/${build_dir}/ggml/src/${release_dir}/libggml-cpu.a"


### PR DESCRIPTION
This will enable using parakeet from the pre-built xcframework libraries. Tested this by using the `build-apple/whisper.xcframework` in my application and successfully using the parakeet APIs.