### PR TITLE
tests: cover audio buffer decoding

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,6 +96,16 @@ target_link_libraries(${UTF8_TEST} PRIVATE common)
 add_test(NAME ${UTF8_TEST} COMMAND ${UTF8_TEST})
 set_tests_properties(${UTF8_TEST} PROPERTIES LABELS "unit")
 
+# Audio byte-buffer decode regression test
+set(AUDIO_BUFFER_TEST test-read-audio-data-buffer)
+add_executable(${AUDIO_BUFFER_TEST} ${AUDIO_BUFFER_TEST}.cpp)
+target_include_directories(${AUDIO_BUFFER_TEST} PRIVATE ../examples)
+target_link_libraries(${AUDIO_BUFFER_TEST} PRIVATE common)
+target_compile_definitions(${AUDIO_BUFFER_TEST} PRIVATE
+    SAMPLE_PATH="${PROJECT_SOURCE_DIR}/samples/jfk.wav")
+add_test(NAME ${AUDIO_BUFFER_TEST} COMMAND ${AUDIO_BUFFER_TEST})
+set_tests_properties(${AUDIO_BUFFER_TEST} PROPERTIES LABELS "unit")
+
 # VAD test tests VAD in isolation
 set(VAD_TEST test-vad)
 add_executable(${VAD_TEST} ${VAD_TEST}.cpp)

--- a/tests/test-read-audio-data-buffer.cpp
+++ b/tests/test-read-audio-data-buffer.cpp
@@ -1,0 +1,51 @@
+#include "common-whisper.h"
+
+#include <cmath>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+static std::vector<char> read_file_bytes(const std::string & path) {
+    std::ifstream input(path, std::ios::binary);
+    assert(input.good());
+    return std::vector<char>(
+            std::istreambuf_iterator<char>(input),
+            std::istreambuf_iterator<char>());
+}
+
+static void assert_pcm_nearly_equal(const std::vector<float> & expected, const std::vector<float> & actual) {
+    assert(expected.size() == actual.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+        assert(std::fabs(expected[i] - actual[i]) < 1e-6f);
+    }
+}
+
+int main() {
+    const std::string sample_path = SAMPLE_PATH;
+    const std::vector<char> wav_data = read_file_bytes(sample_path);
+    assert(!wav_data.empty());
+
+    std::vector<float> pcm_from_file;
+    std::vector<std::vector<float>> stereo_from_file;
+    assert(read_audio_data(sample_path, pcm_from_file, stereo_from_file, false));
+    assert(!pcm_from_file.empty());
+    assert(stereo_from_file.empty());
+
+    std::vector<float> pcm_from_memory;
+    std::vector<std::vector<float>> stereo_from_memory;
+    assert(read_audio_data(wav_data.data(), wav_data.size(), pcm_from_memory, stereo_from_memory, false));
+    assert(!pcm_from_memory.empty());
+    assert(stereo_from_memory.empty());
+
+    assert_pcm_nearly_equal(pcm_from_file, pcm_from_memory);
+
+    printf("Decoded %zu bytes from memory into %zu PCM samples\n", wav_data.size(), pcm_from_memory.size());
+    return 0;
+}


### PR DESCRIPTION
Adds a small regression test for the in-memory audio decoding path used by server multipart uploads without ffmpeg conversion.

The test reads samples/jfk.wav into a byte buffer, decodes it through read_audio_data(const char *, size_t, ...), decodes the same sample through the existing filename path, and asserts the PCM outputs match.

This covers the core regression behind #3819 without requiring a server lifecycle, network harness, ffmpeg, or model download.

Local verification on aarch64:
- cmake --build build-3819-test --target test-read-audio-data-buffer -j2
- ctest --test-dir build-3819-test -R test-read-audio-data-buffer --output-on-failure

Result: 100% tests passed.