### PR TITLE
examples : Improved inference performance of Android example project

### DIFF
--- a/examples/whisper.android.java/app/build.gradle
+++ b/examples/whisper.android.java/app/build.gradle
@@ -25,6 +25,18 @@ android {
   }
 
   buildTypes {
+    debug {
+      externalNativeBuild {
+        cmake {
+          // When the AGP build type is Debug, the native (NDK/CMake) build does not run
+          // compiler optimizations by default, causing a critical performance issue.
+          // We force CMAKE_BUILD_TYPE to Release here so native code stays optimized
+          // even in Debug AGP builds.
+          arguments "-DCMAKE_BUILD_TYPE=Release"
+        }
+      }
+    }
+
     release {
       signingConfig signingConfigs.debug
       minifyEnabled true

--- a/examples/whisper.android/app/build.gradle
+++ b/examples/whisper.android/app/build.gradle
@@ -22,12 +22,25 @@ android {
     }
 
     buildTypes {
+        debug {
+            externalNativeBuild {
+                cmake {
+                    // When the AGP build type is Debug, the native (NDK/CMake) build does not run
+                    // compiler optimizations by default, causing a critical performance issue.
+                    // We force CMAKE_BUILD_TYPE to Release here so native code stays optimized
+                    // even in Debug AGP builds.
+                    arguments "-DCMAKE_BUILD_TYPE=Release"
+                }
+            }
+        }
+
         release {
             signingConfig signingConfigs.debug
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17


### PR DESCRIPTION
Hi, there !

I found that AGP Debug build of `whisper.android` project has critical performance issue.<br/>
So I applied a simple tricky fix to this issue, which is also mentioned from comment of #1070.

Same fix is already applied to [llama.cpp](https://github.com/ggml-org/llama.cpp/pull/5123). 

This PR just applies `CMAKE_BUILD_TYPE=Release` to NDK Build arguments of each `whisper.android` and `whisper.android,java` example project.