### PR TITLE
ci : set GGML_NATIVE=OFF for sanitize builds

### DIFF
--- a/.github/workflows/build-sanitize.yml
+++ b/.github/workflows/build-sanitize.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           cmake . -DCMAKE_BUILD_TYPE=Debug \
             -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON \
+            -DGGML_NATIVE=OFF \
             -DGGML_OPENMP=OFF
           make
 
@@ -65,7 +66,8 @@ jobs:
         if: ${{ matrix.sanitizer == 'ADDRESS' }}
         run: |
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON
+            -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON \
+            -DGGML_NATIVE=OFF
           make
 
       - name: Build (no OpenMP)
@@ -73,6 +75,7 @@ jobs:
         run: |
           cmake . -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DWHISPER_SANITIZE_${{ matrix.sanitizer }}=ON \
+            -DGGML_NATIVE=OFF \
             -DGGML_OPENMP=OFF
           make
 


### PR DESCRIPTION
This commit sets GGML_NATIVE=OFF for all sanitize builds to avoid the case where the compilation happens using a runner that support instructions that may not be available on all runners leading to illegal instruction and failed CI runs.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/28444909499/job/84291639530?pr=3919