### PR TITLE
Fix #587: Remove leading space from txt output

### DIFF
--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -465,7 +465,16 @@ static void output_txt(struct whisper_context * ctx, std::ofstream & fout, const
             speaker = estimate_diarization_speaker(pcmf32s, t0, t1);
         }
 
-        fout << speaker << text << "\n";
+        // strip leading whitespace from each segment (#587)
+        if (!speaker.empty()) {
+            fout << speaker << text;
+        } else {
+            while (*text == ' ' || *text == '\t') {
+                text++;
+            }
+            fout << text;
+        }
+        fout << "\n";
     }
 }
 

--- a/examples/cli/cli.cpp
+++ b/examples/cli/cli.cpp
@@ -465,7 +465,6 @@ static void output_txt(struct whisper_context * ctx, std::ofstream & fout, const
             speaker = estimate_diarization_speaker(pcmf32s, t0, t1);
         }
 
-        // strip leading whitespace from each segment (#587)
         if (!speaker.empty()) {
             fout << speaker << text;
         } else {


### PR DESCRIPTION
The BPE tokenizer used by Whisper produces tokens with leading spaces, causing each line in the txt output to start with an unwanted space.

This fix strips leading whitespace (spaces and tabs) from each segment when writing to txt output files, improving the readability of the transcription output.

Fixes: https://github.com/ggml-org/whisper.cpp/issues/587