### PR TITLE
whisper : run encoder_begin_callback on the language auto-detect path

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -6833,6 +6833,13 @@ int whisper_full_with_state(
     if (params.language == nullptr || strlen(params.language) == 0 || strcmp(params.language, "auto") == 0 || params.detect_language) {
         std::vector<float> probs(whisper_lang_max_id() + 1, 0.0f);
 
+        if (params.encoder_begin_callback) {
+            if (params.encoder_begin_callback(ctx, state, params.encoder_begin_callback_user_data) == false) {
+                WHISPER_LOG_ERROR("%s: encoder_begin_callback returned false - aborting\n", __func__);
+                return -3;
+            }
+        }
+
         const auto lang_id = whisper_lang_auto_detect_with_state(ctx, state, 0, params.n_threads, probs.data());
         if (lang_id < 0) {
             WHISPER_LOG_ERROR("%s: failed to auto-detect language\n", __func__);


### PR DESCRIPTION
encoder_begin_callback is documented as a hook to abort before the encoder runs, but on the language auto-detection path it never gets consulted. When language is null/empty/"auto" or detect_language is set, whisper_full_with_state calls whisper_lang_auto_detect_with_state, which runs the encoder without ever checking the callback. So a caller that returns false to cancel gets ignored during auto-detect and the encode proceeds anyway.

This invokes encoder_begin_callback (when set) right before whisper_lang_auto_detect_with_state. If it returns false, we log and return -3, the same abort behavior already used for the encoder call later in the function. The non-auto-detect paths are unchanged.

Verified against current master that the auto-detect path previously reached the encoder with no callback consultation, and that the callback now fires first and aborts cleanly when it returns false. No automated test added since it is a small control-flow guard.
