### PR TITLE
Fix no_speech_prob calculation

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7164,6 +7164,11 @@ int whisper_full_with_state(
 
                 whisper_batch_prep_legacy(state->batch, prompt.data(), prompt.size(), 0, 0);
 
+                // Identify the SOT position: The first token after prompt
+                const int sot_index = (int) prompt.size() - (int) prompt_init.size();
+                // Include SOT in the decode mask so whisper_decode_internal() will copy to state->logits
+                state->batch.logits[sot_index] = 1;
+
                 if (!whisper_decode_internal(*ctx, *state, state->batch, params.n_threads, false, params.abort_callback, params.abort_callback_user_data)) {
                     WHISPER_LOG_ERROR("%s: failed to decode\n", __func__);
                     return -8;
@@ -7176,8 +7181,13 @@ int whisper_full_with_state(
                     std::vector<float> logprobs(n_logits);
                     std::vector<float> probs(n_logits);
 
-                    whisper_compute_logprobs(state->logits, n_logits, logprobs);
-                    whisper_compute_probs(state->logits, n_logits, logprobs, probs);
+                    // Get the SOT logits, which aren't at position 0 if there was a prompt prefix
+                    const std::vector<float> sot_logits = state->logits;(
+                        state->logits.begin() + (size_t) sot_index * n_logits,
+                        state->logits.begin() + (size_t) (sot_index + 1) * n_logits);
+
+                    whisper_compute_logprobs(sot_logits, n_logits, logprobs);
+                    whisper_compute_probs(sot_logits, n_logits, logprobs, probs);
                     state->no_speech_prob = probs[whisper_token_nosp(ctx)];
                 }
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7182,7 +7182,7 @@ int whisper_full_with_state(
                     std::vector<float> probs(n_logits);
 
                     // Get the SOT logits, which aren't at position 0 if there was a prompt prefix
-                    const std::vector<float> sot_logits = state->logits;(
+                    const std::vector<float> sot_logits(
                         state->logits.begin() + (size_t) sot_index * n_logits,
                         state->logits.begin() + (size_t) (sot_index + 1) * n_logits);
 


### PR DESCRIPTION
## Problem

`no_speech_prob` is always ≈0 because `whisper_decode_internal()` only copies the computed logits when `batch.logits[i]` true (whisper.cpp:2951), which is not the case for the SOT position. Moreover, `no_speech_prob` is calculated from position 0 (`state->logits`, whisper.cpp:7179-7180), but if a prompt prefix is supplied, the SOT is actually after the prefix, so the wrong position is decoded as the SOT for `no_speech_prob`.

This appears to be the root cause of issue #1881.

## Fix

Set mask true for the SOT position before calling `whisper_decode_internal()` in `whisper_full_with_state()`. The SOT position is the next after the prompt prefix, if any. Then, calculate `no_speech_prob` from the computed SOT index based on the actual prefix, rather than always from 0.

## Verification

Using the fixture from #1881, before the fix:
```
build/bin/whisper-cli -m models/ggml-base.bin -l ru -mc 0 -nth 0.6 zeroes.wav
```
yields:
```
[00:00:00.000 --> 00:00:10.000]   [музыка]
```
And the `no_speech_prob` (probe with a temporary `fprint()` where it is calculated) is 2.71956219e-06 ≈ 0.

After the fix, the same command yields `no_speech_prob = 0.905007958`, correctly identifying that no speech is present, and the hallucinated "[музыка]" is suppressed.

## AI disclosure

This issue was identified by Claude Opus 4.8 as the root cause of a bug in a downstream project that depends on this calculation. I have manually verified the diagnosis and the fix that Claude proposed, and I wrote this PR description myself.