### PR TITLE
ruby : detected non-static command inside ` in extsources.rb...

### DIFF
--- a/bindings/ruby/extsources.rb
+++ b/bindings/ruby/extsources.rb
@@ -46,7 +46,7 @@ ignored_exts = %w[
 ]
 
 EXTSOURCES =
-  `git ls-files -z #{root}`.split("\x0")
+  IO.popen(["git", "ls-files", "-z", root.to_s], &:read).split("\x0")
     .collect {|file| Pathname(file)}
     .reject {|file|
       ignored_exts.include?(file.extname) ||


### PR DESCRIPTION
## Summary
Address high severity security finding in `bindings/ruby/extsources.rb`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | ruby.lang.security.dangerous-subshell.dangerous-subshell |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `ruby.lang.security.dangerous-subshell.dangerous-subshell` |
| **File** | `bindings/ruby/extsources.rb:49` |
| **Assessment** | Pattern match — needs manual review |

**Description**: Detected non-static command inside `...`. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.

## Evidence

**Scanner confirmation**: semgrep rule `ruby.lang.security.dangerous-subshell.dangerous-subshell` matched this pattern as ruby.lang.security.dangerous-subshell.dangerous-subshell.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `bindings/ruby/extsources.rb`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
