### PR TITLE
fix: heap out-of-bounds read in log_mel_spectrogram on very short audio

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -3197,8 +3197,12 @@ static bool log_mel_spectrogram(
     // pad 30 seconds of zeros at the end of audio (480,000 samples) + reflective pad 200 samples at the end of audio
     std::fill(samples_padded.begin() + n_samples + stage_2_pad, samples_padded.begin() + n_samples + stage_1_pad + 2 * stage_2_pad, 0);
 
-    // reflective pad 200 samples at the beginning of audio
-    std::reverse_copy(samples + 1, samples + 1 + stage_2_pad, samples_padded.begin());
+    // reflective pad up to 200 samples at the beginning of audio
+    // clamp the reflected count to the available input so very short audio (n_samples <= stage_2_pad)
+    // does not read past the end of `samples`
+    const int64_t n_reflect = std::min<int64_t>(stage_2_pad, std::max<int64_t>(0, (int64_t) n_samples - 1));
+    std::reverse_copy(samples + 1, samples + 1 + n_reflect, samples_padded.begin() + (stage_2_pad - n_reflect));
+
 
     mel.n_mel     = n_mel;
     // https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/SpectralOps.cpp#L936


### PR DESCRIPTION
### Problem
`log_mel_spectrogram` reflect-pads the start of the audio buffer by reading 200 samples starting at
`samples[1]`, with no check that the input has that many samples:

```cpp
// reflective pad 200 samples at the beginning of audio
std::reverse_copy(samples + 1, samples + 1 + stage_2_pad, samples_padded.begin());
// stage_2_pad = WHISPER_N_FFT/2 = 200
```

Any audio shorter than 201 samples (about 12.6 ms at 16 kHz) makes this read past the end of `samples`.
The existing "input is too short" minimum-length check runs later, in `whisper_full_with_state`, only after
`whisper_pcm_to_mel_with_state` (and therefore this read) has already executed, so it does not prevent the
access.

Reproduced with a 5-sample (54-byte) WAV through the stock `whisper-cli`, under an AddressSanitizer build:

```
heap-buffer-overflow  READ of size 4
  #0 std::reverse_copy<...>          bits/stl_algo.h
  #1 log_mel_spectrogram             src/whisper.cpp:3201
  #2 whisper_pcm_to_mel_with_state   src/whisper.cpp:3890
  #3 whisper_full_with_state         src/whisper.cpp:6826
  #4 whisper_full                    src/whisper.cpp:7792
  #5 whisper_full_parallel           src/whisper.cpp:7803
```

(Note: whisper.cpp's `-DWHISPER_SANITIZE_ADDRESS=ON` only instruments `ggml/`, not `src/`, so ASan has to
be passed globally via `CMAKE_*_FLAGS` to catch this.)

### Fix
Clamp the number of reflected samples to what is actually available. For normal-length audio
(`n_samples >= 201`) this is identical to the previous behavior; for shorter input it reflects only the
available samples and leaves the remaining leading pad as the zero-initialized value.

```cpp
const int64_t n_reflect = std::min<int64_t>(stage_2_pad, std::max<int64_t>(0, (int64_t) n_samples - 1));
std::reverse_copy(samples + 1, samples + 1 + n_reflect, samples_padded.begin() + (stage_2_pad - n_reflect));
```

### Testing
- Before: the 5-sample WAV crashes with an ASan heap-buffer-overflow READ at `src/whisper.cpp:3201`.
- After: the same input no longer reads out of bounds; execution reaches the existing "input is too short"
  message and returns cleanly (exit 0). Normal-length audio is unaffected.