### PR TITLE
Fix VAD min silence argument parsing

### DIFF
--- a/examples/vad-speech-segments/speech.cpp
+++ b/examples/vad-speech-segments/speech.cpp
@@ -66,7 +66,7 @@ static bool vad_params_parse(int argc, char ** argv, cli_params & params) {
         else if (arg == "-vm"   || arg == "--vad-model")                   { params.vad_model                   = ARGV_NEXT; }
         else if (arg == "-vt"   || arg == "--vad-threshold")               { params.vad_threshold               = std::stof(ARGV_NEXT); }
         else if (arg == "-vspd" || arg == "--vad-min-speech-duration-ms")  { params.vad_min_speech_duration_ms  = std::stoi(ARGV_NEXT); }
-        else if (arg == "-vsd"  || arg == "--vad-min-silence-duration-ms") { params.vad_min_speech_duration_ms  = std::stoi(ARGV_NEXT); }
+        else if (arg == "-vsd"  || arg == "--vad-min-silence-duration-ms") { params.vad_min_silence_duration_ms = std::stoi(ARGV_NEXT); }
         else if (arg == "-vmsd" || arg == "--vad-max-speech-duration-s")   { params.vad_max_speech_duration_s   = std::stof(ARGV_NEXT); }
         else if (arg == "-vp"   || arg == "--vad-speech-pad-ms")           { params.vad_speech_pad_ms           = std::stoi(ARGV_NEXT); }
         else if (arg == "-vo"   || arg == "--vad-samples-overlap")         { params.vad_samples_overlap         = std::stof(ARGV_NEXT); }


### PR DESCRIPTION
## Summary

Fix `--vad-min-silence-duration-ms` (`-vsd`) parsing in `whisper-vad-speech-segments`.

The option was incorrectly assigned to `vad_min_speech_duration_ms` instead of `vad_min_silence_duration_ms`. As a result, the requested silence duration was ignored and the minimum speech duration was overwritten.

## Testing

- Built `whisper-vad-speech-segments`
- Ran `test-vad`
- Verified long and short option forms produce the same result
- Tested with `jfk.wav` and a 1000 ms minimum silence duration