### PR TITLE
ci : set GGML_NATIVE=OFF for build-vad workflow

### DIFF
--- a/.github/workflows/build-vad.yml
+++ b/.github/workflows/build-vad.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          cmake -B build -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake -B build -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DGGML_NATIVE=OFF
           cmake --build build --config Release
 
       - name: Test


### PR DESCRIPTION
This commit adds the cmake option GGML_NATIVE=OFF to the build-vad workflow to avoid the situation where the ccache is populated with object files containing instructions may not be supported by all runners.

The motivation for this is that the test-vad is currently failing (depending on the runner assigned) with the linked error below.

Refs: https://github.com/ggml-org/whisper.cpp/actions/runs/30625192129/job/91600926109?pr=3963