### PR TITLE
devops : Add main-rocm Dockerfile

### DIFF
--- a/.devops/main-rocm.Dockerfile
+++ b/.devops/main-rocm.Dockerfile
@@ -1,0 +1,81 @@
+# build stage
+FROM registry.fedoraproject.org/fedora:44 AS build
+
+WORKDIR /app
+
+# ROCm 7.14 repository (TheRock release stream)
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[rocm]
+name=ROCm 7.14.0
+baseurl=https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg
+REPO
+EOF
+
+RUN dnf -y --nodocs --setopt=install_weak_deps=False \
+  install \
+  make gcc gcc-c++ cmake git ninja-build rdma-core-devel \
+  amdrocm-core-devel7.14-gfx1151 \
+  && dnf clean all && rm -rf /var/cache/dnf/*
+
+ENV ROCM_PATH=/opt/rocm \
+  HIP_PATH=/opt/rocm \
+  PATH=/opt/rocm/bin:/opt/rocm/core/bin:/opt/rocm/core/lib/llvm/bin:$PATH \
+  LD_LIBRARY_PATH=/opt/rocm/core/lib/rocm_sysdeps/lib:/opt/rocm/core/lib
+
+COPY .. .
+RUN make base.en CMAKE_ARGS="-DGGML_HIP=1 -DAMDGPU_TARGETS=\"gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1152;gfx1200;gfx1201\""
+
+# runtime stage
+FROM registry.fedoraproject.org/fedora-minimal:44 AS runtime
+
+WORKDIR /app
+
+# ROCm 7.14 repository (TheRock release stream)
+RUN <<'EOF'
+tee /etc/yum.repos.d/rocm.repo <<REPO
+[rocm]
+name=ROCm 7.14.0
+baseurl=https://repo.amd.com/rocm/packages-multi-arch/rhel10/x86_64
+enabled=1
+priority=50
+gpgcheck=1
+gpgkey=https://repo.amd.com/rocm/packages-multi-arch/gpg/rocm.gpg
+REPO
+EOF
+
+RUN microdnf -y --nodocs --setopt=install_weak_deps=0 \
+  install \
+  bash ca-certificates libatomic libstdc++ libgcc libgomp libibverbs \
+  amdrocm-runtime7.14 \
+  amdrocm-blas7.14-gfx1100 \
+  amdrocm-blas7.14-gfx1101 \
+  amdrocm-blas7.14-gfx1102 \
+  amdrocm-blas7.14-gfx1103 \
+  amdrocm-blas7.14-gfx1150 \
+  amdrocm-blas7.14-gfx1151 \
+  amdrocm-blas7.14-gfx1152 \
+  amdrocm-blas7.14-gfx1200 \
+  amdrocm-blas7.14-gfx1201 \
+  && microdnf clean all && rm -rf /var/cache/dnf/* \
+  && ln -s core-7.14 /opt/rocm/core \
+  && ln -s core-7.14/bin /opt/rocm/bin \
+  && ln -s core-7.14/include /opt/rocm/include \
+  && ln -s core-7.14/lib /opt/rocm/lib \
+  && ln -s core-7.14/libexec /opt/rocm/libexec \
+  && ln -s core-7.14/lib/llvm /opt/rocm/llvm \
+  && ln -s core-7.14/share /opt/rocm/share \
+  && ln -s core-7.14/lib/llvm/amdgcn /opt/rocm/amdgcn
+
+ENV ROCM_PATH=/opt/rocm \
+  HIP_PATH=/opt/rocm \
+  PATH=/opt/rocm/bin:/opt/rocm/core/bin:/opt/rocm/core/lib/llvm/bin:$PATH \
+  LD_LIBRARY_PATH=/opt/rocm/core/lib/rocm_sysdeps/lib:/opt/rocm/core/lib
+
+COPY --from=build /app /app
+ENV PATH=/app/build/bin:$PATH
+ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
Adds a Dockerfile for a ROCm build.
Based off code from https://github.com/kyuz0/amd-strix-halo-toolboxes/blob/main/toolboxes/Dockerfile.rocm-7.14.


The build and runtime targets:

| GFX target | AMD GPU architecture | Devices |
|---|---|---|
| `gfx1100` | RDNA 3 dGPU | Radeon RX 7900 XTX, RX 7900 XT, RX 7900 GRE; Radeon PRO W7900, W7800 |
| `gfx1101` | RDNA 3 dGPU | Radeon RX 7800 XT, RX 7700 XT; Radeon PRO W7700 |
| `gfx1102` | RDNA 3 dGPU | Radeon RX 7600 XT, RX 7600 |
| `gfx1103` | RDNA 3 iGPU | Radeon 780M and related RDNA 3 integrated GPUs |
| `gfx1150` | RDNA 3.5 APU | Ryzen AI 300-series / Strix Point APUs, including Radeon 890M-class graphics |
| `gfx1151` | RDNA 3.5 APU | Ryzen AI Max/Max+ and PRO 300-series / Strix Halo APUs, including Ryzen AI Max+ PRO 395 and Radeon 8060S |
| `gfx1152` | RDNA 3.5 APU | Certain newer Ryzen AI APUs, including Radeon 860M-class graphics |
| `gfx1200` | RDNA 4 dGPU | Radeon RX 9060 XT and RX 9060 |
| `gfx1201` | RDNA 4 dGPU | Radeon RX 9070 XT, RX 9070 and RX 9070 GRE |


This pull request introduces a new multi-stage Dockerfile, `.devops/main-rocm.Dockerfile`, to support building and running the project with AMD ROCm 7.14 for GPU acceleration. The Dockerfile is split into build and runtime stages, ensuring a clean and efficient image for deployment.

**ROCm Dockerfile addition:**

* Added `.devops/main-rocm.Dockerfile` with a build stage based on Fedora 44, installing ROCm 7.14 development packages and compiling the project with HIP and AMDGPU targets enabled.
* Added a runtime stage based on Fedora Minimal 44, installing only the necessary ROCm runtime and BLAS packages for supported GPU architectures, and copying the built application from the build stage.
* Configured environment variables (`ROCM_PATH`, `HIP_PATH`, `PATH`, `LD_LIBRARY_PATH`) for ROCm compatibility in both build and runtime stages.
* Created symbolic links in `/opt/rocm` to ensure compatibility with ROCm tools and libraries.
* Set the entrypoint to run the application in a Bash shell.

# Testing
* Tested on a `gfx1151` this works.

In my testing I did notice a transcription difference between running main-vulkan-306c88f4d1286aec1bf96e544632897886af5501 v.1.9.2 docker image and main-rocm. Multiple runs would provide consistent output, but the output of vulkan and rocm differed - I'm not sure why. For the most part it was little differences, where I feel ROCm was more accurate, but there was a chunk near the end that ROCm skipped that Vulkan did not. My testing was with `-m ggml-large-v3-turbo-q5_0.bin` and `--vad --vad-model ggml-silero-v6.2.0.bin`

Example small difference - first vulkan (less accurate) then ROCm (more accurate):

```patch
192c178,179
<  of the moment, and most importantly, be grateful.
---
>  Honor the moment.
>  And most importantly, be grateful.
```

The VAD segments are the same in both Vulkan and ROCm.