### PR TITLE
whisper : default-initialize whisper_mel to avoid uninitialized read

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -416,9 +416,9 @@ static const std::map<whisper_alignment_heads_preset, whisper_aheads> g_aheads {
 static std::vector<uint32_t> get_alignment_heads_by_layer(const whisper_context_params & cparams, int il, int32_t n_text_layer, int32_t n_head);
 
 struct whisper_mel {
-    int n_len;
-    int n_len_org;
-    int n_mel;
+    int n_len     = 0;
+    int n_len_org = 0;
+    int n_mel     = 0;
 
     std::vector<float> data;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,16 @@ target_link_libraries(${BUFFER_LOADER_TEST} PRIVATE common)
 add_test(NAME ${BUFFER_LOADER_TEST} COMMAND ${BUFFER_LOADER_TEST})
 set_tests_properties(${BUFFER_LOADER_TEST} PROPERTIES LABELS "unit;gh")
 
+# whisper_full() with n_samples == 0 must not read an uninitialized mel (#3978)
+set(ZERO_SAMPLES_TEST test-whisper-zero-samples)
+add_executable(${ZERO_SAMPLES_TEST} ${ZERO_SAMPLES_TEST}.cpp)
+target_include_directories(${ZERO_SAMPLES_TEST} PRIVATE ../include ../ggml/include ../examples)
+target_link_libraries(${ZERO_SAMPLES_TEST} PRIVATE common)
+target_compile_definitions(${ZERO_SAMPLES_TEST} PRIVATE
+    WHISPER_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/for-tests-ggml-tiny.bin")
+add_test(NAME ${ZERO_SAMPLES_TEST} COMMAND ${ZERO_SAMPLES_TEST})
+set_tests_properties(${ZERO_SAMPLES_TEST} PROPERTIES LABELS "tiny;gh")
+
 # VAD test tests VAD in isolation
 set(VAD_TEST test-vad)
 add_executable(${VAD_TEST} ${VAD_TEST}.cpp)

--- a/tests/test-whisper-zero-samples.cpp
+++ b/tests/test-whisper-zero-samples.cpp
@@ -1,0 +1,30 @@
+#include "whisper.h"
+
+#include <cstdio>
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <cassert>
+
+int main() {
+    struct whisper_context_params cparams = whisper_context_default_params();
+    cparams.use_gpu = false;
+
+    struct whisper_context * ctx = whisper_init_from_file_with_params(WHISPER_MODEL_PATH, cparams);
+    assert(ctx != nullptr);
+
+    struct whisper_full_params params = whisper_full_default_params(WHISPER_SAMPLING_GREEDY);
+    params.no_timestamps = true;
+    params.print_progress = false;
+    params.print_realtime = false;
+
+    const int rc = whisper_full(ctx, params, nullptr, 0);
+    assert(rc == 0);
+    assert(whisper_full_n_segments(ctx) == 0);
+
+    whisper_free(ctx);
+
+    printf("test-whisper-zero-samples: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## What

`whisper_full()` / `whisper_full_with_state()` called with `n_samples == 0` on a
freshly allocated state can dereference a NULL mel buffer inside the encoder, or
silently return 0 — the outcome depends on heap garbage, so the crash is
intermittent.

Give `struct whisper_mel` default member initializers so a never-computed mel
reads as "0 frames".

## Why

The mel spectrogram is only computed when there is audio:
`if (n_samples > 0) { ... whisper_pcm_to_mel_with_state(...) }`. For
`n_samples == 0` the mel is never touched. But `whisper_mel` had no member
initializers, and the state is allocated with `new whisper_state`, so
`mel.n_len / n_len_org / n_mel` were indeterminate heap garbage while `mel.data`
is a correctly-constructed empty vector (NULL data pointer).

`seek_end` is derived from `mel.n_len_org`. If the garbage lands below the
`delta_min` guard the call quietly returns 0; otherwise decoding proceeds and
`whisper_encode_internal` copies the mel with garbage dimensions from the empty
(NULL) buffer → read at address 0. The zero-sample input is reachable from real
use (a push-to-talk recording stopped before the first capture buffer yields a
valid-header, zero-frame WAV).

With the fields default-initialized to 0, `n_samples == 0` deterministically
takes the existing "input too short" path and returns 0 segments. The two code
paths that legitimately set a mel (`log_mel_spectrogram`,
`whisper_set_mel_with_state`) overwrite all three fields before any read, so the
defaults are observable only on the never-computed mel — the bug case.

## Test verification (RED → GREEN)

Added `tests/test-whisper-zero-samples.cpp`: load `for-tests-ggml-tiny.bin`, call
`whisper_full(ctx, params, nullptr, 0)`, assert `rc == 0` and `n_segments == 0`.

Because the read is of uninitialized memory, the deterministic RED is shown with
valgrind on the unpatched struct (only the production change reverted, the new
test applied):

**RED** (upstream base — `whisper_mel` without initializers):
```
==316== Conditional jump or move depends on uninitialised value(s)
==316==    at 0x4987C4C: whisper_full_with_state (whisper.cpp:6886)
==316==    by 0x498B768: whisper_full (whisper.cpp:7811)
==316==    by 0x109375: main (test-whisper-zero-samples.cpp:30)
==316==  Uninitialised value was created by a heap allocation
==316==    by 0x49785B7: whisper_init_state (whisper.cpp:3388)
...
ERROR SUMMARY: (valgrind exit code 1)
```

**GREEN** (with the fix):
```
test-whisper-zero-samples: OK
==75== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
valgrind exit: 0
```

Normal (non-valgrind) run of the new test plus the existing `whisper-cli` tiny
test both pass.

Fixes #3978
