### PR TITLE
models : fix n_text_ctx taken from max_length instead of max_target_positions

### DIFF
--- a/models/convert-h5-to-ggml.py
+++ b/models/convert-h5-to-ggml.py
@@ -84,16 +84,10 @@ encoder = json.load((dir_model / "vocab.json").open("r", encoding="utf8"))
 encoder_added = json.load((dir_model / "added_tokens.json").open( "r", encoding="utf8"))
 hparams = json.load((dir_model / "config.json").open("r", encoding="utf8"))
 
-# Add this block to handle missing 'max_length'
-if "max_length" not in hparams or hparams["max_length"] is None:
-    hparams["max_length"] = hparams.get("max_target_positions", 448)  # Default to 448 if missing
-elif not isinstance(hparams["max_length"], int):
-    try:
-        hparams["max_length"] = int(hparams["max_length"])  # Convert if necessary
-    except ValueError:
-        print(f"Warning: Invalid max_length value '{hparams['max_length']}', using default 448.")
-        hparams["max_length"] = 448
-        
+# n_text_ctx sizes the decoder positional embedding, so it must come from the
+# architecture ('max_target_positions'), not the generation default ('max_length').
+n_text_ctx = hparams.get("max_target_positions") or 448
+
 model = WhisperForConditionalGeneration.from_pretrained(dir_model)
 
 #code.interact(local=locals())
@@ -122,7 +116,7 @@ fout.write(struct.pack("i", hparams["max_source_positions"]))
 fout.write(struct.pack("i", hparams["d_model"]))
 fout.write(struct.pack("i", hparams["encoder_attention_heads"]))
 fout.write(struct.pack("i", hparams["encoder_layers"]))
-fout.write(struct.pack("i", hparams["max_length"]))
+fout.write(struct.pack("i", n_text_ctx))
 fout.write(struct.pack("i", hparams["d_model"]))
 fout.write(struct.pack("i", hparams["decoder_attention_heads"]))
 fout.write(struct.pack("i", hparams["decoder_layers"]))


### PR DESCRIPTION
Closes #3986.

`n_text_ctx` sizes the decoder positional embedding (`src/whisper.cpp:1797`), so it must be
`max_target_positions`, the row count of the `decoder.positional_embedding` tensor this script
writes. It was reading `max_length`, a generation default. The audio side of the header already
uses `max_source_positions`, and `convert-h5-to-coreml.py` already reads `max_target_positions`.

Both fields are 448 on OpenAI's checkpoints, so this is invisible until a fine-tune sets
`max_length`.

Measured with a synthetic checkpoint (`max_target_positions=1024`, `max_length=448`) and
`whisper-cli` built from this tree:

| | master | this change |
|---|---|---|
| fine-tune case | `decoder.positional_embedding has wrong size`, load fails | loads |
| OpenAI-style checkpoint | loads | output `.bin` byte-identical |

#2477 and #2840 used `max_target_positions` as a fallback for a missing or non-int `max_length`;
this makes it the source, so both are subsumed. Their coercion is dropped as unreachable:
`from_pretrained` rejects a non-int, negative or weights-disagreeing value before the header is
written.

Not verified against a real fine-tune. #2778 may be the same bug but has no `config.json` to
confirm it.
