### PR TITLE
fix: stop shadowing proper cuda libraries in runtime docker build

### DIFF
--- a/.devops/main-cuda.Dockerfile
+++ b/.devops/main-cuda.Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
+# The build stage has no real GPU/driver, so the linker needs the
+# forward-compat libcuda stub to resolve CUDA driver-API symbols.
 # Ref: https://stackoverflow.com/a/53464012
 ENV CUDA_MAIN_VERSION=13.0
 ENV LD_LIBRARY_PATH /usr/local/cuda-${CUDA_MAIN_VERSION}/compat:$LD_LIBRARY_PATH
@@ -34,8 +36,6 @@ RUN find /app/build -name "*.o" -delete && \
     rm -rf /app/build/_deps
 
 FROM ${BASE_CUDA_RUN_CONTAINER} AS runtime
-ENV CUDA_MAIN_VERSION=13.0
-ENV LD_LIBRARY_PATH /usr/local/cuda-${CUDA_MAIN_VERSION}/compat:$LD_LIBRARY_PATH
 WORKDIR /app
 
 RUN apt-get update && \


### PR DESCRIPTION
Greetings!

Summary & resolution:
I think the CUDA container build is broken and has been for an extended period.  Some cursory forensics suggest https://github.com/ggml-org/whisper.cpp/pull/1966 as the cause.  The change was CORRECT and NECESSARY for the first stage of the container build (because the runner has no GPU) but the RUNTIME change to the ld_library path shadowed the host machine's ACTUAL configuration upon deployment.  The fix is to simply remove the two problematic env vars in the runtime section of the builder.
```diff
-ENV CUDA_MAIN_VERSION=13.0
-ENV LD_LIBRARY_PATH /usr/local/cuda-${CUDA_MAIN_VERSION}/compat:$LD_LIBRARY_PATH
```
_____________________________________________

I recognize that these are bold claims... it's shocking that the CUDA container could be broken for so long.  But it's a bit sneaky because the nvidia-smi that folks (including Nvidia's own container toolkit docs) often use to test whether a container has GPU support isn't affected.  It isn't until you actually attempt to use Whisper that you'd notice, and even then only if you spot the fallback to CPU in the scrollback.

To sanity check that my WSL/Podman setup wasn't to blame, I tested on a rented VPS running Docker via native GNU/Linux:
```bash
root@C.47644853:/$ whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav
ggml_cuda_init: failed to initialize CUDA: system has unsupported display driver / cuda driver combination
[...]

root@C.47644853:/$ LD_LIBRARY_PATH=$(echo $LD_LIBRARY_PATH | sed 's#/usr/local/cuda-13.0/compat:##')
root@C.47644853:/$ whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 15849 MiB):
  Device 0: NVIDIA GeForce RTX 5060 Ti, compute capability 12.0, VMM: yes, VRAM: 15849 MiB
[...]
```
Slightly different error than under WSL, but sure enough the same problem and solution.  

And it's not just me: https://github.com/ggml-org/whisper.cpp/issues/3814 independently corroborates.  

It is also probably illuminating to contrast with what llama.cpp is doing, as the projects have so much shared heritage and methodology.  
```
whisper.cpp:main-cuda (unpatched, upstream):
  libcuda.so.1 => /usr/local/cuda-13.0/compat/libcuda.so.1

llama.cpp:full-cuda13 (unpatched, upstream):
  libcuda.so.1 => /usr/lib/wsl/drivers/nv_dispi.inf_amd64_b7cca8360c0d57e9/libcuda.so.1
```
This is side-by-side on my WSL/Podman box: you can see that llama leaves the host's cuda linked via the CDI injection where whisper is shadowing it.  So llama.cpp's cuda container works where Whisper.cpp's fails.

Hope we can get this fixed, because I adore whisper.cpp and even still nothing else compares for generating subs (especially for "foreign" language films)... it's a real QoL thing.

Best regards,
FNG