### PR TITLE
server : only enable token timestamps when the response needs them

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -554,8 +554,6 @@ void get_req_parameters(const Request & req, whisper_params & params)
     if (req.has_file("token_timestamps"))
     {
         params.token_timestamps = parse_str_to_bool(req.get_file_value("token_timestamps").content);
-    } else {
-        params.token_timestamps = !params.no_timestamps;
     }
     if (req.has_file("language"))
     {
@@ -624,6 +622,17 @@ void get_req_parameters(const Request & req, whisper_params & params)
     if (req.has_file("no_language_probabilities"))
     {
         params.no_language_probabilities = parse_str_to_bool(req.get_file_value("no_language_probabilities").content);
+    }
+
+    // resolved last, since it depends on response_format / max_len / split_on_word above.
+    // token timestamps also drive the max_len segment wrapping in whisper_full(), so turning
+    // them on unconditionally makes the max_len fallback below wrap every response at 60
+    // characters - on a token boundary, i.e. mid-word. Only default them on when the response
+    // actually carries per-token data (verbose_json) or wrapping was asked for.
+    if (!req.has_file("token_timestamps"))
+    {
+        params.token_timestamps = !params.no_timestamps &&
+            (params.response_format == vjson_format || params.max_len > 0 || params.split_on_word);
     }
 }
 


### PR DESCRIPTION
Fixes #3968.

`21665eab` (#3679, v1.8.4) dropped the format gate on token timestamps:

```diff
-    wparams.token_timestamps = !params.no_timestamps && params.response_format == vjson_format;
+    wparams.token_timestamps = !params.no_timestamps;
```

The `max_len == 0 ? 60` fallback only applies on that path, so since then every
response is wrapped at 60 characters, on a token boundary rather than a word one:

```
default json:            "...your country can\n do for you..."
token_timestamps=false:  "...your country can do for you..."
```

This resolves the default after the other parameters and enables it only for
verbose_json, or when `max_len` or `split_on_word` was asked for. Output matches
v1.8.3 again, and clients passing `max_len` with any format still get wrapping.

I tried clearing the `max_len` fallback instead, but that takes verbose_json from
2 segments to 1.

AI disclosure: an AI assistant helped investigate and draft this. I bisected the
regression, built and ran the server before and after, and can explain any of it.
