### PR TITLE
whisper : bypass cross-attention scaling for OpenVINO backend

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -2310,7 +2310,7 @@ static struct ggml_cgraph * whisper_build_graph_cross(
                 layer.cross_attn_k_w,
                 cur);
 
-#if !defined(GGML_USE_OPENVINO) // scaling is handled internally in OpenVINO backend
+#ifndef GGML_USE_OPENVINO // scaling is handled internally in OpenVINO backend
         Kcross = ggml_scale(ctx0, Kcross, Kscale);
 #endif
 

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -2310,7 +2310,9 @@ static struct ggml_cgraph * whisper_build_graph_cross(
                 layer.cross_attn_k_w,
                 cur);
 
+#if !defined(GGML_USE_OPENVINO) // scaling is handled internally in OpenVINO backend
         Kcross = ggml_scale(ctx0, Kcross, Kscale);
+#endif
 
         struct ggml_tensor * Vcross = ggml_mul_mat(ctx0,
                 layer.cross_attn_v_w,


### PR DESCRIPTION
This PR adds a preprocessor check for `GGML_USE_OPENVINO` to bypass attention scaling in the cross-attention subgraph, since this scaling is handled internally by the OpenVINO backend.