### PR TITLE
Added check for nullptr for wctx in tests : fixing segfault in test-vad-full when the model file is missing

### DIFF
--- a/tests/test-vad-full.cpp
+++ b/tests/test-vad-full.cpp
@@ -27,6 +27,13 @@ int main() {
             whisper_model_path.c_str(),
             cparams);
 
+    // Checking if the model even exists and is not a nullptr
+    if (!wctx) {
+        fprintf(stderr, "failed to load model '%s' - manually download model to pass this test "
+                    "(models/download-ggml-model.sh base.en)\n", whisper_model_path.c_str());
+        return 1;
+    }
+
     struct whisper_full_params wparams = whisper_full_default_params(WHISPER_SAMPLING_BEAM_SEARCH);
     wparams.vad            = true;
     wparams.vad_model_path = vad_model_path.c_str();

--- a/tests/test-vad-full.cpp
+++ b/tests/test-vad-full.cpp
@@ -27,10 +27,8 @@ int main() {
             whisper_model_path.c_str(),
             cparams);
 
-    // Checking if the model even exists and is not a nullptr
     if (!wctx) {
-        fprintf(stderr, "failed to load model '%s' - manually download model to pass this test "
-                    "(models/download-ggml-model.sh base.en)\n", whisper_model_path.c_str());
+        fprintf(stderr, "failed to load model '%s'\n", whisper_model_path.c_str());
         return 1;
     }
 


### PR DESCRIPTION

## Problem

`test-vad-full` crashes with a **segmentation fault** instead of failing  when `models/ggml-base.en.bin` is not present on disk.

Unlike the other CLI tests, which use the small stub models checked into the repo (`models/for-tests-ggml-*.bin`), `test-vad-full` points at the **real** `ggml-base.en.bin` (see `tests/CMakeLists.txt`). That file is not in the repo and is not downloaded by the build, so anyone running the full, unfiltered `ctest` without having fetched it first gets a segfault rather than a useful error.

The crash path is:

1. `tests/test-vad-full.cpp` - `whisper_init_from_file_with_params()` is called and its result stored in `wctx`.
2. `src/whisper.cpp` - `whisper_init_from_file_with_params_no_state()` correctly fails to open the missing file, logs `failed to open '<path>'`, and returns `nullptr`; this propagates out of `whisper_init_from_file_with_params()`.
3. `tests/test-vad-full.cpp` - the return value is never checked, and the now null `wctx` is passed to `whisper_full_parallel()`.
4. `src/whisper.cpp` - `whisper_full_parallel()` with `n_processors == 1`  forwards straight to `whisper_full()`.
5. `src/whisper.cpp` - `whisper_full()` evaluates  `whisper_vad(ctx, ctx->state, ...)`, dereferencing `ctx->state` on a null `ctx`. **This is where the segfault occurs**.

## Fix

Add a null check on `wctx` immediately after the model is loaded, before it is used anywhere, with a message pointing at the download script:

```cpp
// Checking if the model even exists and is not a nullptr
if (!wctx) {
    fprintf(stderr, "failed to load model '%s' - manually download model to pass this test "
                "(models/download-ggml-model.sh base.en)\n", whisper_model_path.c_str());
    return 1;
}
```

## Building

Command used: 

```bash
cmake -B build -DWHISPER_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel

ctest --test-dir build --output-on-failure
```

**Without `models/ggml-base.en.bin` present** - before this change the test aborted with `Exception: SegFault`. After it, the run reports a clean failure with a clear message:

```
12/13 Test #12: test-vad-full ....................***Failed    0.00 sec
whisper_init_from_file_with_params_no_state: failed to open '.../models/ggml-base.en.bin'
failed to load model '.../models/ggml-base.en.bin' - manually download model to pass this test (models/download-ggml-model.sh base.en)
```

**With the model present** (`models/download-ggml-model.sh base.en`): 

```
12/13 Test #12: test-vad-full ....................   Passed    0.53 sec

100% tests passed, 0 tests failed out of 13
```

## AI Disclosure
It is a 3 line check that is added. AI was used but it was reviewed by the author.