### PR TITLE
openvino : update model conversion and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,20 +268,20 @@ This can result in significant speedup in encoder performance. Here are the inst
 
 - Build `whisper.cpp` with OpenVINO support:
 
-  Download OpenVINO package from [release page](https://github.com/openvinotoolkit/openvino/releases). The recommended version to use is [2024.6.0](https://github.com/openvinotoolkit/openvino/releases/tag/2024.6.0). Ready to use Binaries of the required libraries can be found in the [OpenVino Archives](https://storage.openvinotoolkit.org/repositories/openvino/packages/2024.6/)
+  Download OpenVINO package from [release page](https://github.com/openvinotoolkit/openvino/releases). The recommended version to use is [2026.3.0](https://github.com/openvinotoolkit/openvino/releases/tag/2026.3.0). Ready to use Binaries of the required libraries can be found in the [OpenVino Archives](https://storage.openvinotoolkit.org/repositories/openvino/packages/2026.3/)
 
   After downloading & extracting package onto your development system, set up required environment by sourcing setupvars script. For example:
 
   Linux:
 
   ```bash
-  source /path/to/l_openvino_toolkit_ubuntu22_2023.0.0.10926.b4452d56304_x86_64/setupvars.sh
+  source /path/to/openvino_toolkit_ubuntu/setupvars.sh
   ```
 
   Windows (cmd):
 
   ```powershell
-  C:\Path\To\w_openvino_toolkit_windows_2023.0.0.10926.b4452d56304_x86_64\setupvars.bat
+  C:\Path\To\openvino_toolkit_windows\setupvars.bat
   ```
 
   And then build the project using cmake:

--- a/models/convert-whisper-to-openvino.py
+++ b/models/convert-whisper-to-openvino.py
@@ -3,7 +3,7 @@ import torch
 from whisper import load_model
 import os
 from openvino.frontend import FrontEndManager
-from openvino.runtime import serialize
+from openvino import serialize
 import shutil
 
 def convert_encoder(hparams, encoder, mname):

--- a/models/requirements-openvino.txt
+++ b/models/requirements-openvino.txt
@@ -1,2 +1,3 @@
 openvino>=2023.3.0
 openai-whisper
+onnxscript


### PR DESCRIPTION
This commit updates the OpenVINO model conversion script and its dependencies as they were currently not working.

The first issue was an import that needed updating for fix the following error:
```console
  (openvino_conv_env) $ python convert-whisper-to-openvino.py --model base.en
  Traceback (most recent call last):
    File "/home/danbev/work/ai/whisper-work/models/convert-whisper-to-openvino.py", line 6, in <module>
      from openvino.runtime import serialize
  ModuleNotFoundError: No module named 'openvino.runtime'
```
And after that there was a missing dependency:
```console
ModuleNotFoundError: No module named 'onnxscript'
```

With the changes in this commit I was able to successfully convert the model and run the inference using OpenVINO.