### PR TITLE
docs : fix typos in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ First, check if your Ascend NPU device is supported:
 | Atlas 300T A2                 | Support |
 | Atlas 300I Duo                | Support |
 
-Then, make sure you have installed [`CANN toolkit`](https://www.hiascend.com/en/software/cann/community) . The lasted version of CANN is recommanded.
+Then, make sure you have installed [`CANN toolkit`](https://www.hiascend.com/en/software/cann/community) . The latest version of CANN is recommended.
 
 Now build `whisper.cpp` with CANN support:
 

--- a/examples/bench.wasm/README.md
+++ b/examples/bench.wasm/README.md
@@ -44,4 +44,4 @@ cp bin/libbench.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/command.wasm/README.md
+++ b/examples/command.wasm/README.md
@@ -44,4 +44,4 @@ cp bin/libcommand.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/lsp/README.md
+++ b/examples/lsp/README.md
@@ -31,7 +31,7 @@ The vim plugin was designed to closely follow the mnemonics of vim
 
 
 Keys corresponding to a string use that spoken value normally and when a motion is expected, but use the key itself when a character is expected.  
-Keys corresponding to a dict, like `i`, can have manual difinitions given to each possible commandset.
+Keys corresponding to a dict, like `i`, can have manual definitions given to each possible commandset.
 
 0 is normal (insert), 1 is motion (inside), 2 is it's usage as a single key ([till] i), and 3 is it's usage in an area selection (s -> [around] sentence)
 
@@ -89,7 +89,7 @@ Will return an error if any of the commands in the commandset have duplicate tok
 
 `guided`  
 `params.commandset_index` An index returned by a corresponding commandset registration. If not set, the most recently registered commandset is used.
-`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is recieved. This should be left blank unless you have a timestamp from a previous response.  
+`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is received. This should be left blank unless you have a timestamp from a previous response.  
 Responds with  
 `result.command_index` The numerical index (starting from 0) of the detected command in the selected commandset
 `result.command_text` A string containing the command as provided in the commandset
@@ -98,7 +98,7 @@ Responds with
 `unguided`  
 `params.no_context` Sets the corresponding whisper `no_context` param. Defaults to true. Might provide more accurate results for consecutive unguided transcriptions if those after the first are set to false.
 `params.prompt` If provided, sets the initial prompt used during transcription.
-`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is recieved. This should be left blank unless you have a timestamp from a previous response.  
+`params.timestamp` A positive unsigned integer which designates a point in time which audio should begin processing from. If left blank, the start point of audio processing will be the moment the message is received. This should be left blank unless you have a timestamp from a previous response.  
 Responds with  
 `result.transcription` A string containing the transcribed text.  N.B. This will almost always start with a space due to how text is tokenized.
 `result.timestamp` A positive unsigned integer that designates the point in time which audio stopped being processed at. Pass this timestamp back in a subsequent message to mask the latency of transcription.

--- a/examples/stream.wasm/README.md
+++ b/examples/stream.wasm/README.md
@@ -42,4 +42,4 @@ cp bin/libstream.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.

--- a/examples/stream/README.md
+++ b/examples/stream/README.md
@@ -1,7 +1,7 @@
 # whisper.cpp/examples/stream
 
 This is a naive example of performing real-time inference on audio from your microphone.
-The `whisper-stream` tool samples the audio every half a second and runs the transcription continously.
+The `whisper-stream` tool samples the audio every half a second and runs the transcription continuously.
 More info is available in [issue #10](https://github.com/ggerganov/whisper.cpp/issues/10).
 
 ```bash

--- a/examples/sycl/README.md
+++ b/examples/sycl/README.md
@@ -6,11 +6,11 @@ This example program provide the tools for llama.cpp for SYCL on Intel GPU.
 
 |Tool Name| Function|Status|
 |-|-|-|
-|ls-sycl-device| List all SYCL devices with ID, compute capability, max work group size, ect.|Support|
+|ls-sycl-device| List all SYCL devices with ID, compute capability, max work group size, etc.|Support|
 
 ### ls-sycl-device
 
-List all SYCL devices with ID, compute capability, max work group size, ect.
+List all SYCL devices with ID, compute capability, max work group size, etc.
 
 1. Build the llama.cpp for SYCL for all targets.
 

--- a/examples/whisper.wasm/README.md
+++ b/examples/whisper.wasm/README.md
@@ -64,4 +64,4 @@ cp bin/libmain.worker.js /path/to/html/
 
 > 📝 **Note:** As of Emscripten 3.1.58 (April 2024), separate worker.js files are no
 > longer generated and the worker is embedded in the main JS file. So the worker
-> file will not be geneated for versions later than `3.1.58`.
+> file will not be generated for versions later than `3.1.58`.


### PR DESCRIPTION
Nine spelling mistakes across the main readme and seven example readmes:

- `geneated` -> `generated` (bench.wasm, command.wasm, stream.wasm, whisper.wasm)
- `recieved` -> `received` (lsp, twice)
- `difinitions` -> `definitions` (lsp)
- `continously` -> `continuously` (stream)
- `ect` -> `etc` (sycl, twice)
- `lasted` / `recommanded` -> `latest` / `recommended` (main readme, CANN section)

Found with codespell, then each one read in context so nothing inside a code block or
a command example was touched. Docs only -- no code, no build input

AI usage disclosure: I used Claude to run the spell check, prepare the diff and draft
this description. I checked every change myself & I am responsible for what is here