### PR TITLE
ci : release clean-up

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -62,15 +62,15 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tag_name: ${{ steps.checks.outputs.version }}
-          # TODO: remove the prerelease flag once the semantic versioning workflow is ready
-          # ref: https://github.com/ggml-org/ggml/discussions/1579
-          prerelease: true
+          prerelease: false
+          # TODO: enrich the body of the release with more information
           body: |
-            > [!NOTE]
-            > Semantic versioning is still work in progress.
-            > More info can be found in https://github.com/ggml-org/ggml/discussions/1579
+            ## Overview
+
+            New version has been released.
 
             ${{ steps.desc.outputs.nightly }}
+            **More info:** [dist : releases and versioning of ggml-org projects](https://github.com/ggml-org/ggml/discussions/1579)
 
             ## ${{ steps.desc.outputs.changelog_title }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -646,6 +646,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ needs.determine-tag.outputs.tag_name }}
+          prerelease: true
 
       - name: Upload release
         id: upload_release

--- a/scripts/make-release-desc.sh
+++ b/scripts/make-release-desc.sh
@@ -52,10 +52,10 @@ PREV="$( { git tag --list; echo "${VERSION}"; } \
 
 if [[ -n "${PREV}" ]]; then
     CHANGELOG="$(git log --oneline "${PREV}..${RELEASE_COMMIT}")"
-    CHANGELOG_TITLE="Change log since ${PREV}"
+    CHANGELOG_TITLE="Changelog since ${PREV}"
 else
     CHANGELOG="(no previous release tag found)"
-    CHANGELOG_TITLE="Change log"
+    CHANGELOG_TITLE="Changelog"
 fi
 
 # Nightly release: the b* tag pointing at the release commit (|| true: no match is not an error)


### PR DESCRIPTION
This commit applies the same pre offical release clean-up as in llama.cpp.

Refs: https://github.com/ggml-org/llama.cpp/pull/27477