### PR TITLE
docs : add release badge and remove stable/roadmap [no ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 ![whisper.cpp](https://user-images.githubusercontent.com/1991296/235238348-05d0f6a4-da44-4900-a1de-d0707e75b763.jpeg)
 
-[![Actions Status](https://github.com/ggml-org/whisper.cpp/workflows/CI/badge.svg)](https://github.com/ggml-org/whisper.cpp/actions)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![Release](https://img.shields.io/github/v/release/ggml-org/whisper.cpp?filter=v*)](https://github.com/ggml-org/whisper.cpp/releases)
+[![Actions Status](https://github.com/ggml-org/whisper.cpp/workflows/CI/badge.svg)](https://github.com/ggml-org/whisper.cpp/actions)
 [![Conan Center](https://shields.io/conan/v/whisper-cpp)](https://conan.io/center/whisper-cpp)
 [![npm](https://img.shields.io/npm/v/whisper.cpp.svg)](https://www.npmjs.com/package/whisper.cpp/)
-
-Stable: [v1.9.3](https://github.com/ggml-org/whisper.cpp/releases/tag/v1.9.3) / [Roadmap](https://github.com/orgs/ggml-org/projects/4/)
 
 High-performance inference of [OpenAI's Whisper](https://github.com/openai/whisper) automatic speech recognition (ASR) model:
 


### PR DESCRIPTION
This commit updates the README.md to include a release badge.

The motivation for this is that we have been manually updating the Stable link in this document for releases. Removing this means that we don't have to touch this file and only update CMakeLists.txt.

I also removed the link to the Roadmap was it felt out of place and it has not been kept up to date so I hope that is alright.

I'll follow up with a PR to introduce a release script that will help assist the creation of releases (updateing the version and creating the release PR etc).