### PR TITLE
parakeet : fix TDT decode by outputting raw logits from the joint graph

### DIFF
--- a/include/parakeet.h
+++ b/include/parakeet.h
@@ -176,7 +176,8 @@ extern "C" {
     // Token logits obtained from the last call to parakeet_full/parakeet_chunk
     // The logits for the last token are stored in the last row
     // Rows: n_tokens
-    // Cols: n_vocab
+    // Cols: n_vocab + 1 token logits (the blank token is at index n_vocab),
+    //       followed by n_tdt_durations duration logits
     PARAKEET_API float * parakeet_get_logits           (struct parakeet_context * ctx);
     PARAKEET_API float * parakeet_get_logits_from_state(struct parakeet_state * state);
 

--- a/src/parakeet.cpp
+++ b/src/parakeet.cpp
@@ -2302,12 +2302,7 @@ static struct ggml_cgraph * parakeet_build_graph_joint(
     ggml_set_output(logits);
     ggml_set_name(logits, "logits");
 
-    struct ggml_tensor * probs = ggml_soft_max(ctx0, logits);
-    struct ggml_tensor * log_probs = ggml_log(ctx0, probs);
-    ggml_set_output(log_probs);
-    ggml_format_name(log_probs, "log_probs");
-
-    ggml_build_forward_expand(gf, log_probs);
+    ggml_build_forward_expand(gf, logits);
 
     ggml_free(ctx0);
 
@@ -2473,19 +2468,25 @@ static parakeet_token_data create_token_data(
                         float   token_logit,
                           int   n_vocab_logits) {
 
+    float max_logit = token_logit;
+    for (int i = 0; i < n_vocab_logits; ++i) {
+        max_logit = std::max(max_logit, pstate.logits[i]);
+    }
+
     float token_sum = 0.0f;
     for (int i = 0; i < n_vocab_logits; ++i) {
-        token_sum += expf(pstate.logits[i]);
+        token_sum += expf(pstate.logits[i] - max_logit);
     }
-    float token_p = expf(token_logit) / token_sum;
+
+    const float log_z = max_logit + logf(token_sum);
 
     parakeet_token_data token_data;
     token_data.id = token_id;
     token_data.duration_idx = duration_idx;
     token_data.duration_value = duration_value;
     token_data.frame_index = frame_index;
-    token_data.p = token_p;
-    token_data.plog = token_logit;
+    token_data.p = expf(token_logit - log_z);
+    token_data.plog = token_logit - log_z;
     token_data.t0 = frame_index * pctx.model.hparams.subsampling_factor;
     token_data.t1 = (frame_index + duration_value) * pctx.model.hparams.subsampling_factor;
     token_data.is_word_start = is_word_start_token(pctx.vocab, token_id);
@@ -2566,8 +2567,8 @@ static bool parakeet_decode(
         // find the max index of the duration logits, and look up that index
         // value in the tdt_durations array to get the actual duration value.
         int best_duration_idx = 0;
-        float best_duration_logit = -1e10f;
-        for (int i = 0; i < n_tdt_durations; ++i) {
+        float best_duration_logit = pstate.logits[n_vocab_logits];
+        for (int i = 1; i < n_tdt_durations; ++i) {
             if (pstate.logits[n_vocab_logits + i] > best_duration_logit) {
                 best_duration_logit = pstate.logits[n_vocab_logits + i];
                 best_duration_idx = i;


### PR DESCRIPTION
Fix #3932. The fix is similar to [#3948](https://github.com/ggml-org/whisper.cpp/pull/3948) (closed by its author).

Validation: Measures the impact of the issue on `samples/diffusion2023-07-03.flac` against NeMo python implementation.

### Result on a 27:50 file (parakeet-tdt-0.6b-v2 f16, `diffusion2023-07-03.flac`)

| | before | after |
| --- | --- | --- |
| tokens decoded with duration 0 | **3,144 / 7,762 (41%)** | 109 (1.4%) |
| word-end error vs NeMo (3,640 words) | mean **89 ms**, 1,294 words (36%) > 100 ms, 327 > 300 ms | mean **2 ms**, 13 words > 100 ms, 1 > 300 ms |
| word-start error vs NeMo | 63 words > 100 ms | 1 |
| joint evaluations | 14,217 | 9,088 (−36%) |
| decode time (M-series, Metal) | 6,532 ms | 2,196 ms (−66%) |
| transcript | — | 4 near-tie punctuation/word flips (`it. That's`→`it, that's`); jfk.wav identical |

The error is one-sided (signed mean −87 ms): a token that should carry duration 2–4
gets duration 0, so the word ends where its last token *starts*, and the decoder then
advances one frame at a time instead of skipping. Worst cases, all exact after the fix:

| word | NeMo | before | Δ before | Δ after |
| --- | --- | --- | --- | --- |
| wavelength. | 653.20–654.72 | 653.20–653.84 | −0.88 s | 0.00 |
| properties. | 553.92–555.20 | 553.84–554.40 | −0.80 s | 0.00 |
| properties. | 658.48–659.68 | 658.48–658.88 | −0.80 s | 0.00 |
| correctly. | 1194.64–1195.92 | 1194.64–1195.28 | −0.64 s | 0.00 |

Duration histogram `[0,1,2,3,4]` of the decoded tokens:
before `[3144, 1076, 1815, 997, 730]`, after `[109, 1841, 3124, 1627, 1067]`.
The 5-minute excerpt (601 matched words) has the same shape: word-end mean 85 ms → 2 ms,
209 words > 100 ms → 3.


All tested on M3 Max MacBook Pro (Metal). This fix is helped by Claude Code. I'm trying to learn and make support for [parakeet-tdt_ctc-0.6b-ja](https://huggingface.co/nvidia/parakeet-tdt_ctc-0.6b-ja), after testing, I found that this problem was more pronounced in the model.
