### PR TITLE
harden: detected non-static command inside ` in extsources.rb...

### DIFF
--- a/bindings/ruby/extsources.rb
+++ b/bindings/ruby/extsources.rb
@@ -46,7 +46,7 @@ ignored_exts = %w[
 ]
 
 EXTSOURCES =
-  `git ls-files -z #{root}`.split("\x0")
+  IO.popen(["git", "ls-files", "-z", root.to_s]).read.split("\x0")
     .collect {|file| Pathname(file)}
     .reject {|file|
       ignored_exts.include?(file.extname) ||


### PR DESCRIPTION
## Summary
Harden input handling in `bindings/ruby/extsources.rb` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | ruby.lang.security.dangerous-subshell.dangerous-subshell |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `ruby.lang.security.dangerous-subshell.dangerous-subshell` |
| **File** | `bindings/ruby/extsources.rb:49` |
| **Assessment** | Defensive hardening |

**Description**: Detected non-static command inside `...`. If unverified user data can reach this call site, this is a code injection vulnerability. A malicious actor can inject a malicious script to execute arbitrary code.

## Threat Model Context

This is a local CLI tool - exploitation requires the attacker to control command-line arguments or input files.

## Changes
- `bindings/ruby/extsources.rb`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
