### PR TITLE
whisper : re-seed decoder 0 between calls

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7006,6 +7006,13 @@ int whisper_full_with_state(
         return -4;
     }
 
+    // decoder 0 is seeded once in whisper_init_state and skipped by the loop below, so its
+    // generator carries over between calls for the whole lifetime of the state. It is only read
+    // in the temperature > 0 branch, i.e. on the temperature fallback path, which makes the
+    // output a function of how many calls the state has already served: the same audio, decoded
+    // twice, can yield different text. Re-seed it here like every other decoder.
+    state->decoders[0].rng = std::mt19937(0);
+
     // TAGS: WHISPER_DECODER_INIT
     for (int j = 1; j < n_decoders; j++) {
         auto & decoder = state->decoders[j];


### PR DESCRIPTION
Decoder 0 is seeded once in `whisper_init_state()` (`src/whisper.cpp:3551`) and the per-call
re-seeding loop in `whisper_full_with_state()` starts at `j = 1` (`src/whisper.cpp:7010`), so
decoder 0 is never re-seeded. Its `mt19937` carries over from one call to the next for the whole
lifetime of the state.

```cpp
// whisper_init_state
state->decoders[0].rng = std::mt19937(0);   // once, ever

// whisper_full_with_state, every call
for (int j = 1; j < n_decoders; j++) {      // <-- starts at 1
    ...
    decoder.rng = std::mt19937(j);
}
```

`decoder.rng` is only read in the `temperature > 0` branch of `whisper_sample_token`, which is
reached through temperature fallback. So the effect is invisible on clean audio and shows up only
on clips that fall back — where it does not look like a bug, it looks like nondeterminism: **the
output becomes a function of how many calls the state has already served**, and the same audio
decoded twice in the same process can yield different text.

### Reproducing

The trap is that it needs the *same* process. Three noisy 30 s ATC clips, decoded 4 times each
against one `whisper-server` instance (`large-v3-turbo-q5_0`, VAD on, `-l en`):

| | distinct transcripts per clip |
|---|---|
| before | 3 of 3 clips unstable (up to 3 distinct outputs in 4 passes) |
| after | 3 of 3 clips stable |

Fresh processes decoding each clip once hide the issue entirely, which is why it is easy to miss.

Example of the same clip, three passes, before the change:

```
· HOT484, KID, cell level 110. Cell level 11, is a 4404, CJ.
· I've been 484, I'm key to cell level 110. Cell level 11 is a 444 CJ.
· I've been 484, you can see the cell level 110. Cell level 11 is a 444 CJ.
```

### The change

Re-seed decoder 0 alongside the others, with `mt19937(0)` — the same value the loop would give it
(`mt19937(j)` for `j = 0`). One line, no behaviour change for callers that use a single decode per
state, and decoding becomes reproducible across calls.
