### PR TITLE
Cmake edited so that in tests : we can auto-download base.en model to pass the ctest without manually downloading the model

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -133,8 +133,21 @@ target_compile_definitions(${VAD_TEST} PRIVATE
     WHISPER_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/ggml-base.en.bin"
     VAD_MODEL_PATH="${PROJECT_SOURCE_DIR}/models/for-tests-silero-v6.2.0-ggml.bin"
     SAMPLE_PATH="${PROJECT_SOURCE_DIR}/samples/jfk.wav")
+
+set(VAD_MODEL_FIXTURE ggml-base.en-model)
+add_test(NAME download-ggml-base.en
+    COMMAND ${CMAKE_COMMAND}
+        -D "MODEL_URL=https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin"
+        -D "MODEL_PATH=${PROJECT_SOURCE_DIR}/models/ggml-base.en.bin"
+        -P "${CMAKE_CURRENT_SOURCE_DIR}/download-ggml-model.cmake")
+set_tests_properties(download-ggml-base.en PROPERTIES
+    FIXTURES_SETUP ${VAD_MODEL_FIXTURE}
+    LABELS "download")
+
 add_test(NAME ${VAD_TEST} COMMAND ${VAD_TEST})
-set_tests_properties(${VAD_TEST} PROPERTIES LABELS "base;en")
+set_tests_properties(${VAD_TEST} PROPERTIES
+    LABELS "base;en"
+    FIXTURES_REQUIRED ${VAD_MODEL_FIXTURE})
 
 # Parakeet model loading test
 set(PARAKEET_TEST test-parakeet)

--- a/tests/download-ggml-model.cmake
+++ b/tests/download-ggml-model.cmake
@@ -1,0 +1,25 @@
+if (NOT DEFINED MODEL_URL OR NOT DEFINED MODEL_PATH)
+    message(FATAL_ERROR "MODEL_URL and MODEL_PATH must both be defined")
+endif()
+
+if (EXISTS "${MODEL_PATH}")
+    message(STATUS "model already present, skipping download: ${MODEL_PATH}")
+    return()
+endif()
+
+message(STATUS "downloading ${MODEL_URL}")
+
+file(DOWNLOAD "${MODEL_URL}" "${MODEL_PATH}.tmp"
+     STATUS download_status
+     SHOW_PROGRESS)
+
+list(GET download_status 0 status_code)
+if (NOT status_code EQUAL 0)
+    list(GET download_status 1 status_string)
+    file(REMOVE "${MODEL_PATH}.tmp")
+    message(FATAL_ERROR "failed to download ${MODEL_URL}: ${status_string}")
+endif()
+
+file(RENAME "${MODEL_PATH}.tmp" "${MODEL_PATH}")
+
+message(STATUS "model saved to ${MODEL_PATH}")


### PR DESCRIPTION
Follow-up to #3998, which stopped `test-vad-full` from segfaulting when `models/ggml-base.en.bin` is missing. The test now fails cleanly, but it still fails - a plain `ctest` run fails out of the box unless the model is downloaded manually.

`test-vad-full` is the only test needing the real `base.en` model: it asserts an exact transcription, so the stub models checked into the repo (`models/for-tests-*.bin`) won't do. That model is neither committed nor fetched by the build.

## Solution

A CTest fixture that fetches the model on demand, plus a small script (`tests/download-ggml-model.cmake`) that does the download.

## Testing

**Linux** (GCC 13.3, CPU-only), with `models/ggml-base.en.bin` removed:

```
14/16 Test #14: download-ggml-base.en ............   Passed    1.98 sec
15/16 Test #15: test-vad-full ....................   Passed    0.57 sec

100% tests passed, 0 tests failed out of 16
```

**Windows** (Visual Studio, machine that had never downloaded the model):

```
14/16 Test #14: download-ggml-base.en ............   Passed    2.97 sec
15/16 Test #15: test-vad-full ....................   Passed    0.96 sec

100% tests passed out of 16
```
## Reproducing
Linux:

```bash
cmake -B build -DWHISPER_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Release
cmake --build build --parallel
rm -f models/ggml-base.en.bin
ctest --test-dir build --output-on-failure
```

Windows:

```bat
cmake -B build -DWHISPER_BUILD_TESTS=ON
cmake --build build --config Release --parallel
ctest --test-dir build -C Release --output-on-failure
```
## AI Usage
AI was used but the code was manually tested.