### PR TITLE
release : publish macOS CLI binaries (arm64, x64, universal)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,218 @@ jobs:
           path: whisper-bin-ubuntu-${{ matrix.build }}.tar.gz
           name: whisper-bin-ubuntu-${{ matrix.build }}.tar.gz
 
+  macos-cpu:
+    runs-on: ${{ matrix.os }}
+    needs: determine-tag
+    if: ${{ needs.determine-tag.outputs.should_release == 'true' }}
+
+    strategy:
+      matrix:
+        include:
+          - build: arm64
+            os: macos-26
+            defines: "-DGGML_METAL_EMBED_LIBRARY=ON"
+          # macos-15-intel is the last x86_64 image available on Actions.
+          # Metal is off here because the hosted Intel runners have no GPU, which is
+          # the same reason ggml-org/llama.cpp disables it for its x64 macOS build.
+          - build: x64
+            os: macos-15-intel
+            defines: "-DGGML_METAL=OFF"
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: release-${{ matrix.os }}-cpu
+          evict-old-files: 1d
+
+      # Same shape as ubuntu-cpu: backends built as loadable dylibs, one CPU backend per
+      # micro-architecture, selected at load time. GGML_NATIVE has to be off for
+      # GGML_CPU_ALL_VARIANTS to drive the per-variant flags at all; left on, it would
+      # instead compile a single backend for whichever CPU the runner happened to have,
+      # which on a refreshed arm64 image means -mcpu=native+i8mm+sme and a binary that
+      # will not start on an M1. The Apple variants are apple_m1 (dotprod),
+      # apple_m2_m3 (+i8mm) and apple_m4 (+sme), so one archive covers every Mac
+      # without giving up the newer instructions on the machines that have them.
+      - name: Build
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='@loader_path' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3 \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_NATIVE=OFF \
+            -DWHISPER_BUILD_IS_DEV=${{ env.WHISPER_BUILD_IS_DEV }} \
+            ${{ matrix.defines }}
+          cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
+
+      - name: Pack artifacts
+        run: |
+          cp LICENSE ./build/bin/
+          tar -czvf whisper-bin-macos-${{ matrix.build }}.tar.gz \
+            -s ",^\.,whisper-bin-macos-${{ matrix.build }}," \
+            -C ./build/bin .
+
+      # Runs from an extracted copy of the archive rather than from build/bin, so the
+      # test covers what actually ships: @loader_path resolving the dylibs next to the
+      # binary once the tree has moved off the machine that built it.
+      - name: Smoke test
+        run: |
+          mkdir -p "${RUNNER_TEMP}/unpacked"
+          tar -xzf whisper-bin-macos-${{ matrix.build }}.tar.gz \
+            -C "${RUNNER_TEMP}/unpacked" --strip-components 1
+          "${RUNNER_TEMP}/unpacked/whisper-cli" \
+            -m models/for-tests-ggml-base.en.bin \
+            -f samples/jfk.wav
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          path: whisper-bin-macos-${{ matrix.build }}.tar.gz
+          name: whisper-bin-macos-${{ matrix.build }}.tar.gz
+
+  # Fuses the two thin builds above into one universal tree. Everything that exists on
+  # both sides is lipo'd. The CPU and Metal backends are built per micro-architecture and
+  # so only ever exist on one side; those are copied through thin, which is what
+  # GGML_BACKEND_DL expects - the loader walks every libggml-*.so next to the binary
+  # and skips the ones it cannot load, so the backends belonging to the other
+  # architecture are simply never used. Anything else that is one-sided is a packaging
+  # bug and fails the job rather than disappearing from the archive silently.
+  macos-universal:
+    runs-on: macos-26
+    needs:
+      - determine-tag
+      - macos-cpu
+    if: ${{ needs.determine-tag.outputs.should_release == 'true' }}
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Download arm64 artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: whisper-bin-macos-arm64.tar.gz
+          path: ./thin
+
+      - name: Download x64 artifact
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: whisper-bin-macos-x64.tar.gz
+          path: ./thin
+
+      - name: Unpack
+        run: |
+          mkdir -p arm64 x64
+          tar -xzf ./thin/whisper-bin-macos-arm64.tar.gz -C arm64 --strip-components 1
+          tar -xzf ./thin/whisper-bin-macos-x64.tar.gz   -C x64   --strip-components 1
+
+          (cd arm64 && find . \( -type f -o -type l \) | sed 's,^\./,,') | sort > "${RUNNER_TEMP}/arm64.list"
+          (cd x64   && find . \( -type f -o -type l \) | sed 's,^\./,,') | sort > "${RUNNER_TEMP}/x64.list"
+          sort -u "${RUNNER_TEMP}/arm64.list" "${RUNNER_TEMP}/x64.list" > "${RUNNER_TEMP}/all.list"
+
+      - name: Fuse
+        run: |
+          # GGML_BACKEND_DL emits loadable backends as libggml-*.so, one per
+          # micro-architecture, so they have no counterpart in the other tree.
+          # Everything else has to be present on both sides.
+          is_backend() {
+            case "$1" in
+              libggml-*.so) return 0 ;;
+              *)            return 1 ;;
+            esac
+          }
+
+          exists() { [ -e "$1" ] || [ -L "$1" ]; }
+
+          rc=0
+          while IFS= read -r f; do
+            mkdir -p "universal/$(dirname "$f")"
+
+            if exists "arm64/$f" && exists "x64/$f"; then
+              if [ -L "arm64/$f" ]; then
+                cp -a "arm64/$f" "universal/$f"
+              elif file -b "arm64/$f" | grep -q "Mach-O"; then
+                lipo -create "arm64/$f" "x64/$f" -output "universal/$f"
+              else
+                cp -a "arm64/$f" "universal/$f"
+              fi
+            elif is_backend "$(basename "$f")"; then
+              if exists "arm64/$f"; then
+                cp -a "arm64/$f" "universal/$f"
+              else
+                cp -a "x64/$f" "universal/$f"
+              fi
+            else
+              echo "::error::${f} exists for only one architecture and is not a backend"
+              rc=1
+            fi
+          done < "${RUNNER_TEMP}/all.list"
+
+          exit $rc
+
+      # lipo -archs rather than parsing lipo -info, so the check does not depend on the
+      # order the architectures happen to be listed in.
+      - name: Verify
+        run: |
+          rc=0
+          while IFS= read -r f; do
+            if ! { [ -e "universal/$f" ] || [ -L "universal/$f" ]; }; then
+              echo "::error::${f} is missing from the fused tree"
+              rc=1
+              continue
+            fi
+
+            [ -L "universal/$f" ] && continue
+            file -b "universal/$f" | grep -q "Mach-O" || continue
+
+            archs="$(lipo -archs "universal/$f")"
+            case "$(basename "$f")" in
+              libggml-*.so)
+                printf '  backend    %-44s %s\n' "$f" "$archs"
+                ;;
+              *)
+                if [[ " ${archs} " == *" arm64 "* && " ${archs} " == *" x86_64 "* ]]; then
+                  printf '  universal  %-44s %s\n' "$f" "$archs"
+                else
+                  echo "::error::${f} is not universal (${archs})"
+                  rc=1
+                fi
+                ;;
+            esac
+          done < "${RUNNER_TEMP}/all.list"
+
+          exit $rc
+
+      - name: Pack artifacts
+        run: |
+          tar -czvf whisper-bin-macos-universal.tar.gz \
+            -s ",^\.,whisper-bin-macos-universal," \
+            -C ./universal .
+
+      # Only the arm64 slice can be exercised here, since the hosted arm64 runners do not
+      # have Rosetta. The x86_64 slice is the same build the x64 job above already ran
+      # natively, so it is covered there.
+      - name: Smoke test
+        run: |
+          mkdir -p "${RUNNER_TEMP}/unpacked"
+          tar -xzf whisper-bin-macos-universal.tar.gz \
+            -C "${RUNNER_TEMP}/unpacked" --strip-components 1
+          "${RUNNER_TEMP}/unpacked/whisper-cli" \
+            -m models/for-tests-ggml-base.en.bin \
+            -f samples/jfk.wav
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          path: whisper-bin-macos-universal.tar.gz
+          name: whisper-bin-macos-universal.tar.gz
+
   windows:
     runs-on: windows-latest
     needs: determine-tag
@@ -596,6 +808,8 @@ jobs:
     needs:
       - determine-tag
       - ubuntu-cpu
+      - macos-cpu
+      - macos-universal
       - ios-xcode-build
       - windows
       - windows-blas
@@ -629,6 +843,17 @@ jobs:
         with:
           subject-path: 'release/*'
 
+      # One manifest for the whole release rather than a .sha256 next to each archive:
+      # it adds a single asset instead of one per artifact, and it can be checked in one
+      # go with `shasum -a 256 -c SHA256SUMS`. Written after the attestation so the
+      # attested subjects stay exactly the artifacts themselves.
+      - name: Checksum release artifacts
+        run: |
+          cd ./release
+          sha256sum * > "${RUNNER_TEMP}/SHA256SUMS"
+          mv "${RUNNER_TEMP}/SHA256SUMS" .
+          cat SHA256SUMS
+
       - name: Create and push git tag
         run: |
           TAG="${{ needs.determine-tag.outputs.tag_name }}"
@@ -658,7 +883,7 @@ jobs:
             const fs = require('fs');
             const release_id = '${{ steps.create_release.outputs.id }}';
             for (let file of await fs.readdirSync('./release')) {
-              if (path.extname(file) === '.zip' || file.endsWith('.tar.gz')) {
+              if (path.extname(file) === '.zip' || file.endsWith('.tar.gz') || file === 'SHA256SUMS') {
                 console.log('uploadReleaseAsset', file);
                 await github.repos.uploadReleaseAsset({
                   owner: context.repo.owner,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,9 @@ jobs:
             ${{ matrix.defines }}
           cmake --build build --config Release -j $(sysctl -n hw.logicalcpu)
 
+      - name: Test
+        run: ctest --test-dir build -L gh --output-on-failure
+
       - name: Pack artifacts
         run: |
           cp LICENSE ./build/bin/

--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ cmake --build build -j --config Release
 ./build/bin/whisper-cli -f samples/jfk.wav
 ```
 
+### Prebuilt macOS binaries
+
+Releases also ship `whisper-cli` for macOS on the
+[releases page](https://github.com/ggml-org/whisper.cpp/releases), as `arm64`, `x64` and
+`universal` archives, so no build step is needed:
+
+```bash
+# verify the download against the SHA256SUMS asset published with the release
+grep -F whisper-bin-macos-arm64.tar.gz SHA256SUMS | shasum -a 256 -c
+
+tar -xzf whisper-bin-macos-arm64.tar.gz
+cd whisper-bin-macos-arm64
+./whisper-cli -m /path/to/ggml-base.en.bin -f /path/to/audio.wav
+```
+
+The archives are neither signed nor notarized. macOS marks anything downloaded through a
+browser as quarantined, and Finder carries that mark onto the files it extracts, so
+Gatekeeper refuses to run them. Extracting with `tar`, as above, avoids this; otherwise
+clear the flag:
+
+```bash
+xattr -dr com.apple.quarantine whisper-bin-macos-arm64
+```
+
 ---
 
 For a quick demo, simply run `make base.en`.


### PR DESCRIPTION
Closes #4026.

Adds two jobs to `release.yml`:

- **macos-cpu** - `arm64` on `macos-26`, `x86_64` on `macos-15-intel`
- **macos-universal** - `lipo`-fuses the two into a universal tree

Three archives, plus a `SHA256SUMS` manifest covering the whole release and a
README section on using the binaries. Each archive is smoke-tested on its own
runner before upload, from an extracted copy rather than from `build/bin`, so
the test exercises what actually ships and `@loader_path` resolving the dylibs
once the tree has moved off the machine that built it.

### One archive for every Mac

`GGML_BACKEND_DL=ON` with `GGML_CPU_ALL_VARIANTS=ON` , the same approach as
`ubuntu-cpu`'s x64 leg, applied to both architectures here. Backends are
loadable modules, one per micro-architecture, chosen at load time rather than
at build time. ggml ships three Apple variants;  `apple_m1` (DOTPROD),
`apple_m2_m3` (+MATMUL_INT8), `apple_m4` (+NOSVE, SME). Therefore, a single archive
runs on an M1 without giving up the newer instructions on an M4.

`GGML_NATIVE` has to be off for any of that to apply. Left on, the build
produces one backend compiled for the machine it happened to run on: on a
refreshed arm64 image that is `-mcpu=native+dotprod+i8mm+nosve+sme`, which will
not start on an M1. Rather than assume the CMake path, I checked the flags
actually emitted per variant with `GGML_NATIVE` off:

```
apple_m1     -march=armv8.2-a+dotprod
apple_m2_m3  -march=armv8.6-a+dotprod+i8mm
apple_m4     -march=armv9.2-a+dotprod+i8mm+nosve+sme
```

The cost is size, and it lands almost entirely on x86: 4.3M → 9.9M for x64 and
8.5M → 15M for universal, against 4.3M → 4.9M for arm64, since ggml ships three
Apple variants and fourteen x86 ones. That is the price of
one-archive-runs-everywhere, and it is what llama.cpp's `ubuntu-cpu` archives
already pay.

No ggml-org workflow currently builds `GGML_CPU_ALL_VARIANTS` on Apple, so this
would be the first.

### Metal and the universal fuse

Metal is on for `arm64` with an embedded library and off for `x64`, matching
llama.cpp for the reason llama.cpp gives: the hosted Intel runners have no GPU.

Between that and the per-variant CPU backends, the CPU and Metal modules each
exist on exactly one side of the fuse. So the fuse walks the union of both
trees rather than either one alone, files present on both sides are `lipo`'d,
one-sided backends are copied through thin, and anything else that is one-sided
fails the job instead of disappearing from the archive quietly. Iterating a
single tree would have shipped a universal binary with no `x86_64` CPU backend
at all. Backends that do exist on both sides come out fat as normal;
`libggml-blas.so` is built against Accelerate on each architecture and fuses to
`x86_64 arm64`.

Copying the one-sided backends through thin is what `GGML_BACKEND_DL` expects:
the loader scans the directory for backend modules, `dlopen`s each one, and
skips the ones that fail.

A `Verify` step re-checks the fused tree with `lipo -archs`, requiring every
non-backend Mach-O to carry both slices; backends are reported with their arch
rather than asserted on.

Probably worth a line in the release notes so nobody reports the thin backend
modules in the universal archive as a bug.

### Runner choice

`macos-13` became fully unsupported in December 2025. `macos-15-intel` is the
replacement Intel label, available until August 2027, after which Actions drops
`x86_64` entirely and actions/runner-images#13046 states that it will be "the
last available x86_64 image from Actions." llama.cpp's release workflow already
uses both `macos-26` and `macos-15-intel`. Using the native Intel label means
the x64 build is tested on real hardware rather than only cross-compiled.

### Checksums

One `SHA256SUMS` manifest covering every platform, written after the
attestation step so the attested subjects stay exactly the artifacts
themselves. `shasum -a 256 -c SHA256SUMS` checks a full download in one pass;
`--ignore-missing` does the same for a single archive.

This also fixes a bug in the earlier revision of this PR: the per-artifact
`.sha256` files never reached the release, because the asset upload filter in
the release job accepts only `.zip` and `.tar.gz` and dropped them without a
warning. `SHA256SUMS` is added to that filter explicitly.

### README and Gatekeeper

New `### Prebuilt macOS binaries` subsection: verify against `SHA256SUMS`,
extract, run.

The archives are adhoc/linker-signed, not Developer ID signed, not notarized.
macOS quarantines anything downloaded through a browser, and Finder propagates
that flag onto the files it extracts, so Gatekeeper then refuses to run them.
Extracting with `tar` sidesteps it entirely; `xattr -dr com.apple.quarantine`
is documented as the fallback for people who use Finder.

As offered in #4026, I'm happy to wire `codesign` and `notarytool` in behind a
secrets check so the steps no-op on forks, but that needs a Developer ID on the
project's Apple account, which I can't supply.

### Verification

Both macOS jobs run green on my fork:
[run 33704402855](https://github.com/apollo-2006/whisper.cpp/actions/runs/33704402855)
on `macos-26` and `macos-15-intel`, with `macos-universal` passing its fuse,
verify and smoke-test steps. Run from a scratch branch with the non-macOS jobs
stripped and `should_release` forced; the two job definitions themselves are
unmodified.

The rest could not come from hosted runners, so it was done locally: Apple M4,
macOS 26.6.2, Apple clang 21.0.0, both architectures built with the workflow's
exact flags and fused with the workflow's own script.

- Fused tree: 22 non-backend Mach-O files, all universal, and 19 backend
  modules, 18 thin, plus `libggml-blas.so` fat. Zero errors from the verify
  step.
- Load-time variant selection demonstrated across three machines with the same
  archive. On the `macos-26` runner, an Apple Paravirtual GPU, reporting
  `MTLGPUFamilyApple5`, it loads `libggml-cpu-apple_m1.so`. On a local M4 it
  loads `libggml-cpu-apple_m4.so`. Under Rosetta its `x86_64` slice loads
  `libggml-cpu-sse42.so`; Rosetta exposes no AVX2, so a real Intel Mac lands on
  `haswell` or better. One archive, three variants, selected at load time
  rather than pinned at build time.
- All three archives extracted standalone and ran: rpath `@loader_path`,
  install names `@rpath/…`, `minos 13.3` on both slices, symlinks preserved
  through both the fuse and the tar.
- Backends for the other architecture fail to load silently rather than
  printing errors: `ggml_backend_load_all_from_path` sets `silent = true`
  under `NDEBUG`.
- `SHA256SUMS` round-trips, excludes itself, and the README one-liner exits 1
  on a corrupted file.
