### PR TITLE
tests : load backends before init when built with GGML_BACKEND_DL

### DIFF
--- a/tests/test-parakeet.cpp
+++ b/tests/test-parakeet.cpp
@@ -111,6 +111,8 @@ static int test_valid_model() {
 }
 
 int main(){
+    ggml_backend_load_all();
+
     if(test_valid_model() != 0){
         return 1;
     }

--- a/tests/test-vad-full.cpp
+++ b/tests/test-vad-full.cpp
@@ -13,6 +13,8 @@
 #include <cassert>
 
 int main() {
+    ggml_backend_load_all();
+
     std::string whisper_model_path = WHISPER_MODEL_PATH;
     std::string vad_model_path     = VAD_MODEL_PATH;
     std::string sample_path        = SAMPLE_PATH;

--- a/tests/test-vad.cpp
+++ b/tests/test-vad.cpp
@@ -48,6 +48,8 @@ struct whisper_vad_segments * test_detect_timestamps(
 }
 
 int main() {
+    ggml_backend_load_all();
+
     std::string vad_model_path = VAD_MODEL_PATH;
     std::string sample_path    = SAMPLE_PATH;
 

--- a/tests/test-whisper-zero-samples.cpp
+++ b/tests/test-whisper-zero-samples.cpp
@@ -8,6 +8,8 @@
 #include <cassert>
 
 int main() {
+    ggml_backend_load_all();
+
     struct whisper_context_params cparams = whisper_context_default_params();
     cparams.use_gpu = false;
 


### PR DESCRIPTION
Fixes #4030.

`ggml_backend_load_all()` at the top of `main()` in the four tests that
initialise a context. Every example already does this:
`examples/cli/cli.cpp`, `bench`, `quantize`, `lsp`,
`vad-speech-segments`. The tests were the only callers that did not.

With `GGML_BACKEND_DL=ON` no backend is registered until something calls it,
so `whisper_init_*` and `parakeet_init_*` ran with `devices = 0` and aborted
on `GGML_ASSERT(device)` in `ggml_backend_dev_backend_reg`.

No new include: `ggml_backend_load_all()` is already reachable through
`whisper.h` and `parakeet.h`, both of which pull in `ggml-cpu.h`, which
includes `ggml-backend.h`.

### Before / after

Full suite on a `-DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON` build,
macOS 26.6.2 / arm64, Apple clang 21.0.0:

| test | before | after |
| --- | --- | --- |
| `test-whisper-zero-samples` | aborted | passes |
| `test-vad` | aborted | passes |
| `test-parakeet` | aborted | passes |
| `test-vad-full` | aborted | reaches init, see below |

`ctest -L gh` goes from 2 of 4 to 4 of 4. The full suite goes from three
aborts to none.

`test-vad-full` is labelled `base;en` rather than `gh` because it needs a real
`models/ggml-base.en.bin`, which I do not have locally. It had the same fault
and the fix is verified the same way: before, it printed `devices = 0` and hit
`GGML_ASSERT(device)`; after, it prints `devices = 3` and gets through
initialisation. Substituting the stub model it then fails its own
`assert(n_segments == 1)`, identically on a `GGML_BACKEND_DL` and a normal
build, which is the stub having no segments rather than anything to do with
this change.

### Regression check

The same suite on a build without `GGML_BACKEND_DL` is unchanged; 14 of 15
before and after, the one failure being `test-vad-full` for the missing model
described above. Both configurations now produce identical results.

### Why CI did not catch it

None of the workflows pairs the two. `build-clang.yml`, `build-gcc.yml` and
`build-sanitize.yml` run `ctest -L gh` but never set `GGML_BACKEND_DL`;
`release.yml` sets it but runs no tests. Adding a `ctest` step to a
`GGML_BACKEND_DL` job would cover the combination, but that felt like a
separate change from fixing the tests, so I have left it out here.
