### PR TITLE
cmake : add version.h.in files for whisper and parakeet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,16 +211,8 @@ set_target_properties(whisper PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DI
 
 install(TARGETS whisper LIBRARY PUBLIC_HEADER)
 
-target_compile_definitions(whisper PRIVATE
-    WHISPER_VERSION="${WHISPER_VERSION}"
-)
-
 set_target_properties(parakeet PROPERTIES PUBLIC_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/include/parakeet.h)
 install(TARGETS parakeet LIBRARY PUBLIC_HEADER)
-
-target_compile_definitions(parakeet PRIVATE
-    PARAKEET_VERSION="${WHISPER_VERSION}"
-)
 
 configure_package_config_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/cmake/whisper-config.cmake.in

--- a/examples/test-cmake/CMakeLists.txt
+++ b/examples/test-cmake/CMakeLists.txt
@@ -5,11 +5,12 @@ set(CMAKE_CXX_STANDARD 17)
 
 # request a version that is satisfied by both dev (1.9.2-dev) and release (1.9.2) installs
 # (find_package does not accept a pre-release version as an argument)
-find_package(whisper 1.9.2 REQUIRED)
+find_package(whisper  1.9.2 REQUIRED)
+find_package(parakeet 1.9.2 REQUIRED)
 
 add_executable(test-cmake test-cmake.cpp)
 
-target_link_libraries(test-cmake PRIVATE whisper)
+target_link_libraries(test-cmake PRIVATE whisper parakeet)
 
 target_compile_definitions(test-cmake PRIVATE
     WHISPER_BUILD_NUMBER=${WHISPER_BUILD_NUMBER}

--- a/examples/test-cmake/test-cmake.cpp
+++ b/examples/test-cmake/test-cmake.cpp
@@ -1,9 +1,13 @@
 #include "whisper.h"
+#include "parakeet.h"
 
 #include <cstdio>
 
 int main(void) {
     printf("[test-cmake] version: %s, build: %d (%s)\n",
            whisper_version(), WHISPER_BUILD_NUMBER, WHISPER_BUILD_COMMIT);
+
+    printf("[test-cmake] parakeet version: %s, build: %d (%s)\n",
+           parakeet_version(), WHISPER_BUILD_NUMBER, WHISPER_BUILD_COMMIT);
     return 0;
 }

--- a/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android.java/app/src/main/jni/whisper/CMakeLists.txt
@@ -9,12 +9,14 @@ set(WHISPER_LIB_DIR ${CMAKE_SOURCE_DIR}/../../../../../../../)
 file(READ "${WHISPER_LIB_DIR}/CMakeLists.txt" MAIN_CMAKE_CONTENT)
 string(REGEX MATCH "project\\(\"whisper\\.cpp\" VERSION ([0-9]+\\.[0-9]+\\.[0-9]+)\\)" VERSION_MATCH "${MAIN_CMAKE_CONTENT}")
 if(CMAKE_MATCH_1)
-    set(WHISPER_VERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
+    set(WHISPER_VERSION ${CMAKE_MATCH_1})
 else()
-    set(WHISPER_VERSION "unknown" PARENT_SCOPE)
+    set(WHISPER_VERSION "unknown")
 endif()
 
 message(STATUS " Whisper version: ${WHISPER_VERSION}")
+
+configure_file(${WHISPER_LIB_DIR}/src/whisper-version.h.in ${CMAKE_CURRENT_BINARY_DIR}/whisper-version.h @ONLY)
 
 set(SOURCE_FILES
     ${WHISPER_LIB_DIR}/src/whisper.cpp
@@ -37,7 +39,7 @@ function(build_library target_name)
 
     target_link_libraries(${target_name} ${LOG_LIB} android ggml)
     target_compile_definitions(${target_name} PUBLIC GGML_USE_CPU)
-    target_compile_definitions(${target_name} PRIVATE WHISPER_VERSION="${WHISPER_VERSION}")
+    target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
     if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)

--- a/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
+++ b/examples/whisper.android/lib/src/main/jni/whisper/CMakeLists.txt
@@ -9,12 +9,14 @@ set(WHISPER_LIB_DIR ${CMAKE_SOURCE_DIR}/../../../../../../..)
 file(READ "${WHISPER_LIB_DIR}/CMakeLists.txt" MAIN_CMAKE_CONTENT)
 string(REGEX MATCH "project\\(\"whisper\\.cpp\" VERSION ([0-9]+\\.[0-9]+\\.[0-9]+)\\)" VERSION_MATCH "${MAIN_CMAKE_CONTENT}")
 if(CMAKE_MATCH_1)
-    set(WHISPER_VERSION ${CMAKE_MATCH_1} PARENT_SCOPE)
+    set(WHISPER_VERSION ${CMAKE_MATCH_1})
 else()
-    set(WHISPER_VERSION "unknown" PARENT_SCOPE)
+    set(WHISPER_VERSION "unknown")
 endif()
 
 message(STATUS " Whisper version: ${WHISPER_VERSION}")
+
+configure_file(${WHISPER_LIB_DIR}/src/whisper-version.h.in ${CMAKE_CURRENT_BINARY_DIR}/whisper-version.h @ONLY)
 
 # Path to external GGML, otherwise uses the copy in whisper.cpp.
 option(GGML_HOME "whisper: Path to external GGML source" OFF)
@@ -37,7 +39,7 @@ function(build_library target_name)
     )
 
     target_compile_definitions(${target_name} PUBLIC GGML_USE_CPU)
-    target_compile_definitions(${target_name} PRIVATE WHISPER_VERSION="${WHISPER_VERSION}")
+    target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
     if (${target_name} STREQUAL "whisper_v8fp16_va")
         target_compile_options(${target_name} PRIVATE -march=armv8.2-a+fp16)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -214,7 +214,11 @@ set_target_properties(parakeet PROPERTIES
     MACHO_CURRENT_VERSION 0 # keep macOS linker from seeing oversized version number
 )
 
-target_include_directories(whisper PUBLIC . ../include)
+configure_file(whisper-version.h.in  ${CMAKE_CURRENT_BINARY_DIR}/whisper-version.h  @ONLY)
+configure_file(parakeet-version.h.in ${CMAKE_CURRENT_BINARY_DIR}/parakeet-version.h @ONLY)
+
+target_include_directories(whisper  PUBLIC . ../include PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(parakeet PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_features   (whisper PUBLIC cxx_std_11) # don't bump
 
 if (CMAKE_CXX_BYTE_ORDER STREQUAL "BIG_ENDIAN")

--- a/src/parakeet-version.h.in
+++ b/src/parakeet-version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define PARAKEET_VERSION "@WHISPER_VERSION@"

--- a/src/parakeet.cpp
+++ b/src/parakeet.cpp
@@ -1,5 +1,6 @@
 #include "parakeet.h"
 #include "parakeet-arch.h"
+#include "parakeet-version.h"
 
 #include "ggml.h"
 #include "ggml-cpp.h"

--- a/src/whisper-version.h.in
+++ b/src/whisper-version.h.in
@@ -1,0 +1,3 @@
+#pragma once
+
+#define WHISPER_VERSION "@WHISPER_VERSION@"

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1,5 +1,6 @@
 #include "whisper.h"
 #include "whisper-arch.h"
+#include "whisper-version.h"
 
 #include "ggml.h"
 #include "ggml-cpp.h"


### PR DESCRIPTION
This commit adds to version.h.in cmake configure files for whisper.cpp and parakeet.cpp, and removes the current version handling which is using compile flag definitions. This was a mistake on my part when introducing version handling and the reason is that compile definitions become part of the compiler flags for all source files in the target. This meant that when the version is updated the flags will be updated add cause a recompile even if the sources have not changed.

parakeet.cpp is given a separate header but shares the version with whisper.cpp at the moment.

Refs: https://github.com/ggml-org/llama.cpp/pull/28278
