### PR TITLE
server : return language in detect response

### DIFF
--- a/examples/server/server.cpp
+++ b/examples/server/server.cpp
@@ -1165,6 +1165,9 @@ int main(int argc, char ** argv) {
             json jres = json{
                 {"text", results}
             };
+            if (params.detect_language) {
+                jres["language"] = whisper_lang_str_full(whisper_full_lang_id(ctx));
+            }
             res.set_content(jres.dump(-1, ' ', false, json::error_handler_t::replace),
                             "application/json");
         }


### PR DESCRIPTION
When `detect_language=true` is used with `response_format=json`, the server detects the language but returns only an empty `text` field.

Before this change:

```bash
curl -s http://127.0.0.1:8080/inference \
  -F file=@/work/audio.wav \
  -F response_format=json \
  -F detect_language=true \
  -F language=auto
```

```json
{"text":""}
```

After this change:

```json
{"text":"","language":"portuguese"}
```

It uses `whisper_full_lang_id(ctx)`.

Tested with `ggml-tiny.bin`. Also tested:

```bash
cmake --build build --target whisper-server -j2
ctest --output-on-failure -R 'test-whisper-zero-samples|test-whisper-buffer-loader'
```

Resolves: https://github.com/ggml-org/whisper.cpp/issues/3603