### PR TITLE
devops : reduce Vulkan Docker image to 39.4% of its original size (now 692 MB)

### DIFF
--- a/.devops/main-vulkan.Dockerfile
+++ b/.devops/main-vulkan.Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04 AS build
 WORKDIR /app
 
-RUN apt-get update && \
-  apt-get install -y build-essential wget cmake git libvulkan-dev spirv-headers glslc \
+RUN apt update && \
+  apt install --no-install-recommends -y build-essential ca-certificates cmake git glslc libvulkan-dev spirv-headers wget \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY .. .
@@ -11,8 +11,9 @@ RUN --mount=type=secret,id=HF_TOKEN,required=false,env=HF_TOKEN make base.en CMA
 FROM ubuntu:24.04 AS runtime
 WORKDIR /app
 
-RUN apt-get update && \
-  apt-get install -y curl ffmpeg libsdl2-dev wget cmake git libvulkan1 mesa-vulkan-drivers \
+RUN apt update && \
+  apt install --no-install-recommends -y \
+    ca-certificates curl ffmpeg libsdl2-dev wget cmake git libvulkan1 mesa-vulkan-drivers \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY --from=build /app /app

--- a/.devops/main-vulkan.Dockerfile
+++ b/.devops/main-vulkan.Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /app
 
 RUN apt update && \
   apt install --no-install-recommends -y \
-    ca-certificates curl ffmpeg libsdl2-dev wget cmake git libvulkan1 mesa-vulkan-drivers \
+    ca-certificates curl ffmpeg libvulkan1 mesa-vulkan-drivers \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 COPY --from=build /app /app

--- a/.devops/main-vulkan.Dockerfile
+++ b/.devops/main-vulkan.Dockerfile
@@ -30,4 +30,3 @@ RUN apt update && \
 COPY --from=build /runtime/ /
 COPY --from=build /app/models/download-* /usr/local/bin/
 RUN ldconfig
-ENTRYPOINT [ "bash", "-c" ]

--- a/.devops/main-vulkan.Dockerfile
+++ b/.devops/main-vulkan.Dockerfile
@@ -7,6 +7,17 @@ RUN apt update && \
 
 COPY .. .
 RUN --mount=type=secret,id=HF_TOKEN,required=false,env=HF_TOKEN make base.en CMAKE_ARGS="-DGGML_VULKAN=1"
+# Copy only CLI executables and shared libraries (not compiled tests, nor source code or other build artifacts)
+RUN mkdir -p /runtime/usr/local/bin /runtime/usr/local/lib && \
+    for path in build/bin/*; do \
+      name="${path##*/}"; \
+      case "$name" in \
+        *.so|*.so.*) cp -a "$path" /runtime/usr/local/lib/ ;; \
+        test-*|main|bench) ;; \
+        *) cp -a "$path" /runtime/usr/local/bin/ ;; \
+      esac; \
+    done
+
 
 FROM ubuntu:24.04 AS runtime
 WORKDIR /app
@@ -16,6 +27,7 @@ RUN apt update && \
     ca-certificates curl ffmpeg libvulkan1 mesa-vulkan-drivers \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
-COPY --from=build /app /app
-ENV PATH=/app/build/bin:$PATH
+COPY --from=build /runtime/ /
+COPY --from=build /app/models/download-* /usr/local/bin/
+RUN ldconfig
 ENTRYPOINT [ "bash", "-c" ]

--- a/README.md
+++ b/README.md
@@ -561,31 +561,54 @@ We have multiple Docker images available for this project:
 ### Usage
 
 ```shell
+# Use the main tag or: cublas, main-cuda, main-intel, main-musa, main-rocm, main-vulkan.
+IMAGE="ghcr.io/ggml-org/whisper.cpp:main"
+MODEL_PATH="/tmp/whisper.cpp-models"
+AUDIO_PATH="/tmp/whisper.cpp-audio"
+AUDIO_URL="https://github.com/ggml-org/whisper.cpp/raw/refs/heads/master/samples/jfk.wav"
+mkdir -p "$MODEL_PATH" "$AUDIO_PATH"
+wget -O "$AUDIO_PATH/jfk.wav" "$AUDIO_URL"
+
 # download model and persist it in a local folder
 docker run -it --rm \
-  -v path/to/models:/models \
-  whisper.cpp:main download-ggml-model.sh base /models
+  -v $MODEL_PATH:/models \
+  $IMAGE \
+  download-ggml-model.sh base /models
 
 # transcribe an audio file
 docker run -it --rm \
-  -v path/to/models:/models \
-  -v path/to/audios:/audios \
-  whisper.cpp:main whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav
-
-# transcribe an audio file in samples folder
-docker run -it --rm \
-  -v path/to/models:/models \
-  whisper.cpp:main whisper-cli -m /models/ggml-base.bin -f ./samples/jfk.wav
+  -v $MODEL_PATH:/models \
+  -v $AUDIO_PATH:/audios \
+  $IMAGE \
+  whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav
 
 # run the web server
-docker run -it --rm -p "8080:8080" \
-  -v path/to/models:/models \
-  whisper.cpp:main whisper-server --host 127.0.0.1 -m /models/ggml-base.bin
-
-# run the bench too on the small.en model using 4 threads
 docker run -it --rm \
-  -v path/to/models:/models \
-  whisper.cpp:main whisper-bench -m /models/ggml-small.en.bin -t 4
+  -p "8080:8080" \
+  -v $MODEL_PATH:/models \
+  $IMAGE \
+  whisper-server --host 0.0.0.0 -m /models/ggml-base.bin
+# then:
+curl -v http://127.0.0.1:8080/inference \
+  -F "file=@${AUDIO_PATH}/jfk.wav" \
+  -F 'response_format=json'
+
+# download small.en and run the bench on it using 4 threads
+docker run -it --rm \
+  -v $MODEL_PATH:/models \
+  $IMAGE \
+  download-ggml-model.sh small.en /models
+docker run -it --rm \
+  -v $MODEL_PATH:/models \
+  $IMAGE \
+  whisper-bench -m /models/ggml-small.en.bin -t 4
+
+# the methods above use the CPU - use your GPU by sharing the device, for example, for an AMD iGPU via Vulkan:
+docker run --rm \
+  --device /dev/dri \
+  -v $MODEL_PATH:/models \
+  "ghcr.io/ggml-org/whisper.cpp:main-vulkan" \
+  whisper-bench -m /models/ggml-small.en.bin -t 4
 ```
 
 ## Installing with Conan

--- a/README.md
+++ b/README.md
@@ -564,28 +564,28 @@ We have multiple Docker images available for this project:
 # download model and persist it in a local folder
 docker run -it --rm \
   -v path/to/models:/models \
-  whisper.cpp:main "./models/download-ggml-model.sh base /models"
+  whisper.cpp:main download-ggml-model.sh base /models
 
 # transcribe an audio file
 docker run -it --rm \
   -v path/to/models:/models \
   -v path/to/audios:/audios \
-  whisper.cpp:main "whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav"
+  whisper.cpp:main whisper-cli -m /models/ggml-base.bin -f /audios/jfk.wav
 
 # transcribe an audio file in samples folder
 docker run -it --rm \
   -v path/to/models:/models \
-  whisper.cpp:main "whisper-cli -m /models/ggml-base.bin -f ./samples/jfk.wav"
+  whisper.cpp:main whisper-cli -m /models/ggml-base.bin -f ./samples/jfk.wav
 
 # run the web server
 docker run -it --rm -p "8080:8080" \
   -v path/to/models:/models \
-  whisper.cpp:main "whisper-server --host 127.0.0.1 -m /models/ggml-base.bin"
-  
+  whisper.cpp:main whisper-server --host 127.0.0.1 -m /models/ggml-base.bin
+
 # run the bench too on the small.en model using 4 threads
 docker run -it --rm \
   -v path/to/models:/models \
-  whisper.cpp:main "whisper-bench -m /models/ggml-small.en.bin -t 4"
+  whisper.cpp:main whisper-bench -m /models/ggml-small.en.bin -t 4
 ```
 
 ## Installing with Conan


### PR DESCRIPTION
The current Vulkan Docker image is 1.75 GB. Making it smaller not only reduces download and storage requirements, but can also make the image faster to build and distribute. This PR applies 4 changes to `main-vulkan.Dockerfile`, reducing the final image size from 1.75 GB to 692 MB (39.4% of the original size). The build time also decreased from 2m41s to 2m16s (84.4% of the original).

These were the main contributors to the current image size:
- Installing recommended APT packages
- Installing development packages in the runtime/final stage
- Copying the entire repository and build artifacts into the runtime/final stage (including the `base.en` model)

I also made a couple of improvements:
- Use `apt` instead of `apt-get`
- Remove `bash -c` as the entrypoint

I'm willing to apply the same changes to the other Dockerfiles in the repository if the maintainers approve this approach. I started with the Vulkan image because it's the one I use.

Result:

```text
$ docker image ls whispercpp-test
REPOSITORY        TAG                                   IMAGE ID       CREATED          SIZE
whispercpp-test   04-remove-entrypoint                  70eb4215ee40   11 minutes ago   692MB
whispercpp-test   03-copy-only-needed-files             57eeec07fb51   19 minutes ago   692MB
whispercpp-test   02-remove-dev-packages-from-runtime   35cde18f6236   22 minutes ago   1.37GB
whispercpp-test   01-do-not-install-recommends          5677b0c472aa   28 minutes ago   1.6GB
whispercpp-test   00-original                           2b93628d52a7   31 minutes ago   1.75GB
```

Notes:

1. Regarding `libsdl2-dev` (removed in the second commit): commit bea43e0c (not mine) introduced this package in the runtime image, but since it's not required for production use, I think it should instead be installed by users who need it in an image derived from this one.
2. I've run all the `docker run` commands from the README using the final Dockerfile in this PR and everything worked as expected (the examples were also fixed/extended).