### PR TITLE
whisper : fix int overflow in whisper_full_parallel chunk offsets

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7975,10 +7975,14 @@ int whisper_full_parallel(
     for (int i = 0; i < n_processors - 1; ++i) {
         auto& results_i = states[i]->result_all;
 
+        // time offset of this chunk in 10 ms units, computed in 64-bit to avoid
+        // int overflow for chunk boundaries beyond ~22 min at 16 kHz
+        const int64_t chunk_offset_t = (100LL * (i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
+
         for (auto& result : results_i) {
             // correct the segment timestamp taking into account the offset
-            result.t0 += 100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
-            result.t1 += 100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
+            result.t0 += chunk_offset_t;
+            result.t1 += chunk_offset_t;
 
             // make sure that segments are not overlapping
             if (!ctx->state->result_all.empty()) {
@@ -8020,7 +8024,8 @@ int whisper_full_parallel(
     WHISPER_LOG_WARN("\n");
     WHISPER_LOG_WARN("%s: the audio has been split into %d chunks at the following times:\n", __func__, n_processors);
     for (int i = 0; i < n_processors - 1; ++i) {
-        WHISPER_LOG_WARN("%s: split %d - %s\n", __func__, (i + 1), to_timestamp(100*((i + 1)*n_samples_per_processor)/WHISPER_SAMPLE_RATE + offset_t).c_str());
+        const int64_t split_t = (100LL * (i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
+        WHISPER_LOG_WARN("%s: split %d - %s\n", __func__, (i + 1), to_timestamp(split_t).c_str());
     }
     WHISPER_LOG_WARN("%s: the transcription quality may be degraded near these boundaries\n", __func__);
 


### PR DESCRIPTION
Fixes #4039.

`whisper_full_parallel()` computed the per-chunk time offset as `100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE` in `int` before adding it to the `int64_t offset_t`. For chunk boundaries later than ~22 min at 16 kHz (`100 * samples > INT_MAX`) the multiplication overflows, corrupting the merged segment `t0`/`t1` and the split times printed in the log.

This PR computes the offset once per chunk in `int64_t` (`100LL * ...`) and reuses it for both the segment merge and the split-time log.

**Verification** — 46 min file (`samples/jfk.wav` looped), `--processors 2`, boundary at 23:00:

Before, built with `-fsanitize=undefined`:
```
src/whisper.cpp:7980:30: runtime error: signed integer overflow: 100 * 22080000 cannot be represented in type 'int'
src/whisper.cpp:7981:30: runtime error: signed integer overflow: 100 * 22080000 cannot be represented in type 'int'
src/whisper.cpp:8023:9:  runtime error: signed integer overflow: 100 * 22080000 cannot be represented in type 'int'
whisper_full_parallel: split 1 - 00:-21:-44.-350
```

After: no overflow reports, `split 1 - 00:23:00.000`, all segment `offsets` in the JSON output non-negative and monotonic. `--processors 4` (Release) reports splits at 00:11:30 / 00:23:00 / 00:34:30.

Note: on Apple clang Release builds the UB happens to yield the correct value, which is why this is mostly seen on MSVC/Windows (as in the issue); the UBSan build reproduces it on macOS.

I have a small regression test (`whisper_full_parallel` on a 45 min silent buffer with `duration_ms = 1000`, checking the logged split time via `whisper_log_set`; ~3 s, fails on master with `00:-22:-14.-350`). Happy to add it to this PR or a follow-up if you'd like it.

Token-level timestamps in parallel mode (#2036, #3726) are a separate issue and unchanged here.