### PR TITLE
ci : update close-issue job to not close issues

### DIFF
--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -1,4 +1,4 @@
-name: Close inactive issues
+name: Mark inactive issues stale
 on:
   schedule:
     - cron: "42 0 * * *"
@@ -9,7 +9,7 @@ permissions:
   issues: write
 
 jobs:
-  close-issues:
+  mark-issues:
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -19,9 +19,9 @@ jobs:
         with:
           exempt-issue-labels: "refactor,help wanted,good first issue,research,bug,roadmap"
           days-before-issue-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-close: -1
           stale-issue-label: "stale"
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          stale-issue-message: "This issue was marked as stale because it has been inactive for 30 days."
           days-before-pr-stale: -1
           days-before-pr-close: -1
           operations-per-run: 10000


### PR DESCRIPTION
This commit updates the close-issue CI job to not automatically close issues. It also adds a stale lable message that explains why the issue was marked as stale.

The motivation for this is that we enabled this job recently and there have been a few comments from users/reporters that they did not get any notification or motivation for closing. Hopefully marking the issues as stale will give a notification the the reporters and we can manually look through stale issues.

Refs: https://github.com/ggml-org/whisper.cpp/issues/586#issuecomment-5579674875