### PR TITLE
ci : cover GGML_BACKEND_DL in ubuntu-22-clang-arm64

### DIFF
--- a/.github/workflows/build-clang.yml
+++ b/.github/workflows/build-clang.yml
@@ -93,6 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         build: [Debug, Release]
+        backend_dl: ['OFF', 'ON']
 
     steps:
       - name: Clone
@@ -101,7 +102,7 @@ jobs:
       - name: ccache
         uses: ggml-org/ccache-action@v1.2.21
         with:
-          key: clang-arm64-${{ matrix.build }}
+          key: clang-arm64-${{ matrix.build }}-dl-${{ matrix.backend_dl }}
           evict-old-files: 1d
           save: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
 
@@ -116,6 +117,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
             -DCMAKE_CXX_COMPILER=clang++ \
             -DCMAKE_C_COMPILER=clang \
+            -DGGML_BACKEND_DL=${{ matrix.backend_dl }} \
             -DGGML_NATIVE=OFF \
             -DGGML_CPU_ARM_ARCH=armv8-a
           make


### PR DESCRIPTION
Follow-up to #4031, which ended by saying a `ctest` step on a `GGML_BACKEND_DL` job would cover the combination but belonged in its own change. This is that change.

#4030 shipped because no workflow pairs the two. `build-clang.yml`, `build-gcc.yml` and `build-sanitize.yml` run `ctest -L gh` but never set `GGML_BACKEND_DL`; `release.yml` sets it but runs no tests. So three of the four tests that initialise a context aborted on `GGML_ASSERT(device)` under `GGML_BACKEND_DL=ON` and CI stayed green the whole time.

Three lines in `build-clang.yml`:

- `ubuntu-22-clang-arm64` matrix gains `backend_dl: ['OFF', 'ON']`
- the cmake line gains `-DGGML_BACKEND_DL=${{ matrix.backend_dl }}`
- the ccache key gains `-dl-${{ matrix.backend_dl }}`

Two legs become four.

### Why this job

Native arm64 runner, no Docker and no QEMU. It already runs `ctest -L gh` and already triggers on push, pull_request and workflow_dispatch, so the coverage arrives without touching anything else in the workflow.

### Does the guard catch #4030

Reverting #4031 on a `-DGGML_BACKEND_DL=ON` build, `ctest -L gh`:

| test | #4031 reverted | master |
| --- | --- | --- |
| `test-whisper-zero-samples` | aborted | passes |
| `test-parakeet` | aborted | passes |
| total | 2 of 4 | 4 of 4 |

The ON legs go red on a tree carrying the bug and green on master. That is the whole argument for the change.

### Why the values are quoted

YAML reads bare ON/OFF as booleans. Unquoted they reach cmake as true/false and render as `dl-true` in job names. Quoted they stay OFF/ON, and the job names on the fork run read `(Debug, OFF)` and `(Release, ON)`.

### Why the ccache key changes

`GGML_CCACHE` is `option(...)` ON at `ggml/CMakeLists.txt:125`, and `ggml/src/CMakeLists.txt:68` auto-detects ccache into `RULE_LAUNCH_COMPILE`. So this job uses ccache even though its cmake line never sets a `COMPILER_LAUNCHER`. Without the key change the OFF and ON legs would race to save one entry on a master push. `save:` is gated to push-on-master, so PRs only restore.

### Verification

[Fork run 34251240356](https://github.com/apollo-2006/whisper.cpp/actions/runs/34251240356) on `ubuntu-22.04-arm`, four legs, all green. Both ON legs log `-DGGML_BACKEND_DL=ON` in the configure step and finish `100% tests passed, 0 tests failed out of 4`.

### Not in this PR

`build-gcc.yml` and `build-sanitize.yml` could take the same axis. One job is enough to guard the combination and extra legs cost runner time, so I have left them alone. The release path is separate: `release.yml` sets `GGML_BACKEND_DL=ON` and runs no tests, and `macos-cpu` is the only place that flag meets `GGML_CPU_ALL_VARIANTS=ON` on Apple hardware. That is #4029.

