### PR TITLE
ci : add Windows On ARM support to release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,6 +530,266 @@ jobs:
           name: whisper-cublas-${{ matrix.cuda-toolkit }}-bin-${{ matrix.arch }}.zip
           path: whisper-cublas-${{ matrix.cuda-toolkit }}-bin-${{ matrix.arch }}.zip
 
+  windows-arm64-cpu:
+    runs-on: windows-2022
+    needs: determine-tag
+
+    strategy:
+      matrix:
+        build: [Release]
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Ninja
+        run: |
+          choco install ninja
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: release-windows-arm64-cpu
+          evict-old-files: 1d
+
+      - name: Configure and Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64_arm64
+          cmake -S . -B build -G "Ninja Multi-Config" ^
+            -D CMAKE_TOOLCHAIN_FILE=cmake/arm64-windows-llvm.cmake ^
+            -DBUILD_SHARED_LIBS=ON ^
+            -DGGML_NATIVE=OFF ^
+            -DGGML_BACKEND_DL=ON ^
+            -DWHISPER_SDL2=OFF ^
+            -DWHISPER_BUILD_IS_DEV=${{ env.WHISPER_BUILD_IS_DEV }}
+          cmake --build build --config ${{ matrix.build }}
+
+      - name: Copy OpenMP runtime DLL
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallPath = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          if (-not $vsInstallPath) {
+            Write-Error "Could not find a Visual Studio install with the ARM64 MSVC toolset"
+            exit 1
+          }
+          $redistVersion = Get-ChildItem "$vsInstallPath\VC\Redist\MSVC" -Directory |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+$' } |
+            Sort-Object Name -Descending | Select-Object -First 1
+          $ompDll = "$vsInstallPath\VC\Redist\MSVC\$($redistVersion.Name)\debug_nonredist\arm64\Microsoft.VC143.OpenMP.LLVM\libomp140.aarch64.dll"
+          if (-not (Test-Path $ompDll)) {
+            Write-Error "libomp140.aarch64.dll not found at $ompDll"
+            exit 1
+          }
+          Copy-Item $ompDll "build\bin\${{ matrix.build }}\" -Force
+
+      - name: Pack bin artifacts
+        shell: pwsh
+        run: |
+              Compress-Archive -Path "build/bin/${{ matrix.build }}" -DestinationPath "whisper-bin-win-cpu-arm64.zip"
+
+      - name: Upload binaries
+        if: ${{ needs.determine-tag.outputs.should_release == 'true' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: whisper-bin-win-cpu-arm64.zip
+          path: whisper-bin-win-cpu-arm64.zip
+
+  windows-arm64-opencl-adreno:
+    runs-on: windows-2022
+    needs: determine-tag
+
+    strategy:
+      matrix:
+        build: [Release]
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Ninja
+        run: |
+          choco install ninja
+
+      - name: Install OpenCL Headers and Libs
+        run: |
+          git clone https://github.com/KhronosGroup/OpenCL-Headers
+          cd OpenCL-Headers
+          cmake -B build `
+            -DBUILD_TESTING=OFF `
+            -DOPENCL_HEADERS_BUILD_TESTING=OFF `
+            -DOPENCL_HEADERS_BUILD_CXX_TESTS=OFF `
+            -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
+          cmake --build build --target install
+          cd ..
+          git clone https://github.com/KhronosGroup/OpenCL-ICD-Loader
+          cd OpenCL-ICD-Loader
+          cmake -B build-arm64-release `
+            -A arm64 `
+            -DCMAKE_PREFIX_PATH="$env:RUNNER_TEMP/opencl-arm64-release" `
+            -DCMAKE_INSTALL_PREFIX="$env:RUNNER_TEMP/opencl-arm64-release"
+          cmake --build build-arm64-release --target install --config release
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: release-windows-arm64-opencl-adreno
+          evict-old-files: 1d
+
+      - name: Configure and Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64_arm64
+          cmake -S . -B build -G "Ninja Multi-Config" ^
+            -D CMAKE_TOOLCHAIN_FILE=cmake/arm64-windows-llvm.cmake ^
+            -DCMAKE_PREFIX_PATH="%RUNNER_TEMP%/opencl-arm64-release" ^
+            -DBUILD_SHARED_LIBS=ON ^
+            -DGGML_NATIVE=OFF ^
+            -DGGML_BACKEND_DL=ON ^
+            -DGGML_OPENCL=ON ^
+            -DGGML_OPENCL_USE_ADRENO_KERNELS=ON ^
+            -DWHISPER_SDL2=OFF ^
+            -DWHISPER_BUILD_IS_DEV=${{ env.WHISPER_BUILD_IS_DEV }}
+          cmake --build build --config ${{ matrix.build }}
+
+      - name: Copy OpenMP runtime DLL
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallPath = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          if (-not $vsInstallPath) {
+            Write-Error "Could not find a Visual Studio install with the ARM64 MSVC toolset"
+            exit 1
+          }
+          $redistVersion = Get-ChildItem "$vsInstallPath\VC\Redist\MSVC" -Directory |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+$' } |
+            Sort-Object Name -Descending | Select-Object -First 1
+          $ompDll = "$vsInstallPath\VC\Redist\MSVC\$($redistVersion.Name)\debug_nonredist\arm64\Microsoft.VC143.OpenMP.LLVM\libomp140.aarch64.dll"
+          if (-not (Test-Path $ompDll)) {
+            Write-Error "libomp140.aarch64.dll not found at $ompDll"
+            exit 1
+          }
+          Copy-Item $ompDll "build\bin\${{ matrix.build }}\" -Force
+
+      - name: Pack bin artifacts
+        shell: pwsh
+        run: |
+              Compress-Archive -Path "build/bin/${{ matrix.build }}" -DestinationPath "whisper-bin-win-opencl-adreno-arm64.zip"
+
+      - name: Upload binaries
+        if: ${{ needs.determine-tag.outputs.should_release == 'true' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: whisper-bin-win-opencl-adreno-arm64.zip
+          path: whisper-bin-win-opencl-adreno-arm64.zip
+
+  windows-arm64-cuda:
+    runs-on: windows-2022
+    needs: determine-tag
+
+    strategy:
+      matrix:
+        build: [Release]
+        cuda-toolkit: [13.4.0]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Install Ninja
+        run: |
+          choco install ninja
+
+      - name: Install ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: ${{ github.job }}-${{ matrix.cuda-toolkit }}-${{ matrix.build }}
+          evict-old-files: 5d
+
+      # nvcc cross-compiles for ARM64 from this x64 runner using the ARM64-targeting
+      # host cl.exe; the CUDA runtime/cublas libs still need their own ARM64 archives
+      # since the standard x64 CUDA packages don't ship ARM64 binaries.
+      - name: Install Cuda Toolkit 13.4.0 (ARM64 target)
+        run: |
+          $CUDA_TOOLKIT_DIR = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.4"
+          $PKG = "https://packages.nvidia.com/bin-archive/pool"
+          $PKG_ID = "5B515474-7E78-11F1-8656-C51E4F4B317F"
+
+          mkdir -p $CUDA_TOOLKIT_DIR
+          choco install unzip -y
+
+          curl -O "$PKG/windows-x86_64/$PKG_ID/cccl-windows-x86_64-13.3.4.1.2-archive.zip"
+          curl -O "$PKG/windows-x86_64/$PKG_ID/cuda_crt-windows-x86_64-13.4.46-archive.zip"
+          curl -O "$PKG/windows-x86_64/$PKG_ID/cuda_nvcc-windows-x86_64-13.4.46-archive.zip"
+          curl -O "$PKG/windows-x86_64/$PKG_ID/libnvvm-windows-x86_64-13.4.46-archive.zip"
+          curl -O "$PKG/windows-arm64/$PKG_ID/cuda_cudart-windows-arm64-13.4.46-archive.zip"
+          curl -O "$PKG/windows-arm64/$PKG_ID/libcublas-windows-arm64-13.7.0.10-archive.zip"
+
+          unzip '*.zip' -d $CUDA_TOOLKIT_DIR
+
+          xcopy "$CUDA_TOOLKIT_DIR\cccl-windows-x86_64-13.3.4.1.2-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_crt-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_nvcc-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\libnvvm-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_cudart-windows-arm64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\libcublas-windows-arm64-13.7.0.10-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+
+          echo "$CUDA_TOOLKIT_DIR\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CUDA_PATH=$CUDA_TOOLKIT_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Configure and Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" amd64_arm64
+          cmake -S . -B build -G "Ninja Multi-Config" ^
+            -D CMAKE_TOOLCHAIN_FILE=cmake/arm64-windows-llvm-cuda.cmake ^
+            -DCMAKE_BUILD_TYPE=${{ matrix.build }} ^
+            -DGGML_CUDA=ON ^
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ^
+            -DGGML_BACKEND_DL=ON ^
+            -DGGML_NATIVE=OFF ^
+            -DWHISPER_SDL2=OFF ^
+            -DWHISPER_BUILD_IS_DEV=${{ env.WHISPER_BUILD_IS_DEV }}
+          cmake --build build --config ${{ matrix.build }}
+
+      - name: Copy CUDA runtime DLLs
+        run: |
+          Get-ChildItem "$env:CUDA_PATH\bin\arm64" -Filter "cudart64_*.dll" | Copy-Item -Destination "build/bin/${{ matrix.build }}"
+          Get-ChildItem "$env:CUDA_PATH\bin\arm64" -Filter "cublas64_*.dll" | Copy-Item -Destination "build/bin/${{ matrix.build }}"
+          Get-ChildItem "$env:CUDA_PATH\bin\arm64" -Filter "cublasLt64_*.dll" | Copy-Item -Destination "build/bin/${{ matrix.build }}"
+
+      - name: Copy OpenMP runtime DLL
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallPath = & $vswhere -latest -products '*' -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+          if (-not $vsInstallPath) {
+            Write-Error "Could not find a Visual Studio install with the ARM64 MSVC toolset"
+            exit 1
+          }
+          $redistVersion = Get-ChildItem "$vsInstallPath\VC\Redist\MSVC" -Directory |
+            Where-Object { $_.Name -match '^\d+\.\d+\.\d+$' } |
+            Sort-Object Name -Descending | Select-Object -First 1
+          $ompDll = "$vsInstallPath\VC\Redist\MSVC\$($redistVersion.Name)\debug_nonredist\arm64\Microsoft.VC143.OpenMP.LLVM\libomp140.aarch64.dll"
+          if (-not (Test-Path $ompDll)) {
+            Write-Error "libomp140.aarch64.dll not found at $ompDll"
+            exit 1
+          }
+          Copy-Item $ompDll "build\bin\${{ matrix.build }}\" -Force
+
+      - name: Pack bin artifacts
+        shell: pwsh
+        run: |
+              Compress-Archive -Path "build/bin/${{ matrix.build }}" -DestinationPath "whisper-bin-win-cuda-${{ matrix.cuda-toolkit }}-arm64.zip"
+
+      - name: Upload binaries
+        if: ${{ needs.determine-tag.outputs.should_release == 'true' }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: whisper-bin-win-cuda-${{ matrix.cuda-toolkit }}-arm64.zip
+          path: whisper-bin-win-cuda-${{ matrix.cuda-toolkit }}-arm64.zip
+
   ios-xcode-build:
     runs-on: macos-latest
     needs: determine-tag
@@ -600,6 +860,9 @@ jobs:
       - windows
       - windows-blas
       - windows-cublas
+      - windows-arm64-cpu
+      - windows-arm64-opencl-adreno
+      - windows-arm64-cuda
 
     steps:
       - name: Clone

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -910,6 +910,8 @@ jobs:
         with:
           tag_name: ${{ needs.determine-tag.outputs.tag_name }}
           prerelease: true
+          body: |
+            **Note:** the Windows arm64 (CUDA) build (`whisper-bin-win-cuda-*-arm64.zip`) uses a preview edition of the CUDA Toolkit for Windows on Arm and should be considered experimental.
 
       - name: Upload release
         id: upload_release

--- a/cmake/arm64-windows-llvm-cuda.cmake
+++ b/cmake/arm64-windows-llvm-cuda.cmake
@@ -1,0 +1,24 @@
+include( ${CMAKE_CURRENT_LIST_DIR}/arm64-windows-llvm.cmake )
+
+if ( DEFINED CUDAToolkit_ROOT )
+    file( TO_CMAKE_PATH "${CUDAToolkit_ROOT}" CUDA_ROOT )
+elseif ( DEFINED ENV{CUDA_PATH} )
+    file( TO_CMAKE_PATH "$ENV{CUDA_PATH}" CUDA_ROOT )
+else()
+    message( FATAL_ERROR "Set CUDAToolkit_ROOT or CUDA_PATH to a Windows CUDA Toolkit with ARM64 target libraries" )
+endif()
+
+if ( DEFINED ENV{VCToolsInstallDir} )
+    file( TO_CMAKE_PATH "$ENV{VCToolsInstallDir}" MSVC_TOOLS_ROOT )
+    set( CMAKE_CUDA_HOST_COMPILER "${MSVC_TOOLS_ROOT}/bin/Hostx64/arm64/cl.exe" CACHE FILEPATH "" )
+endif()
+
+set( CMAKE_CUDA_COMPILER "${CUDA_ROOT}/bin/nvcc.exe" CACHE FILEPATH "" )
+set( CMAKE_CUDA_FLAGS_INIT "-target-dir=arm64" )
+
+# FindCUDAToolkit selects lib/x64 from the host architecture on Windows.
+set( CUDA_CUDART              "${CUDA_ROOT}/lib/arm64/cudart.lib"   CACHE FILEPATH "" )
+set( CUDA_cudart_LIBRARY      "${CUDA_ROOT}/lib/arm64/cudart.lib"   CACHE FILEPATH "" )
+set( CUDA_cublas_LIBRARY      "${CUDA_ROOT}/lib/arm64/cublas.lib"   CACHE FILEPATH "" )
+set( CUDA_cublasLt_LIBRARY    "${CUDA_ROOT}/lib/arm64/cublasLt.lib" CACHE FILEPATH "" )
+set( CUDA_cuda_driver_LIBRARY "${CUDA_ROOT}/lib/arm64/cuda.lib"     CACHE FILEPATH "" )


### PR DESCRIPTION
This commit adds Windows On Arm (WoA) support to whisper.cpp and the release process.

The underlying support was already in place as this had been synced with ggml, but the missing part was producesing release artifacts which is what this commit does.

----

<details><summary>Release artifacts (from fork)</summary>

System info:
```console
OS: Windows (ARM64-based PC), build 10.0.28000
CPU/GPU: NVIDIA RTX Spark
Compiler: clang version 22.1.8, Target: aarch64-pc-windows-msv
```
### CPU
Download and unpack:
```console
$ Invoke-WebRequest -Uri "https://github.com/danbev/whisper.cpp/releases/download/b5128/whisper-bin-win-cpu-arm64.zip" -OutFile "whisper-bin-win-cpu-arm64.zip"
$ Expand-Archive -Path "whisper-bin-win-cpu-arm64.zip" -DestinationPath "whisper-bin-win-cpu-arm64"
```
Run:
```console
$ .\whisper-bin-win-cpu-arm64\Release\whisper-cli.exe -m models\ggml-small.bin -f samples\jfk.wav
load_backend: loaded CPU backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-cpu-arm64\Release\ggml-cpu.dll
whisper_init_from_file_with_params_no_state: loading model from 'models\ggml-small.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
whisper_init_with_params_no_state: devices    = 1
whisper_init_with_params_no_state: backends   = 1
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 768
whisper_model_load: n_audio_head  = 12
whisper_model_load: n_audio_layer = 12
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 768
whisper_model_load: n_text_head   = 12
whisper_model_load: n_text_layer  = 12
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 3 (small)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:          CPU total size =   487.01 MB
whisper_model_load: model size    =  487.01 MB
whisper_backend_init_gpu: device 0: CPU (type: 0)
whisper_backend_init_gpu: no GPU found
whisper_init_state: kv self size  =   18.87 MB
whisper_init_state: kv cross size =   56.62 MB
whisper_init_state: kv pad  size  =    4.72 MB
whisper_init_state: compute buffer (conv)   =   22.42 MB
whisper_init_state: compute buffer (encode) =   33.85 MB
whisper_init_state: compute buffer (cross)  =    6.20 MB
whisper_init_state: compute buffer (decode) =   97.28 MB
read_audio_data: reading audio data from 'samples\jfk.wav' ...
read_audio_data: trying to decode with miniaudio

system_info: n_threads = 4 / 18 | WHISPER : VITISAI = 0 | COREML = 0 | OPENVINO = 0 | CPU : NEON = 1 | ARM_FMA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | OPENMP = 1 | REPACK = 1 |

main: processing 'samples\jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = en, task = transcribe, timestamps = 1 ...


[00:00:00.000 --> 00:00:11.000]   And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =   352.08 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     7.93 ms
whisper_print_timings:   sample time =    79.87 ms /   147 runs (     0.54 ms per run)
whisper_print_timings:   encode time =  3348.20 ms /     1 runs (  3348.20 ms per run)
whisper_print_timings:   decode time =     6.64 ms /     1 runs (     6.64 ms per run)
whisper_print_timings:   batchd time =   715.97 ms /   144 runs (     4.97 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =  4569.80 ms
````
----

### opencl-adreno.

Download and unpack:
```console
$  Invoke-WebRequest -Uri "https://github.com/danbev/whisper.cpp/releases/download/b5128/whisper-bin-win-opencl-adreno-arm64.zip" -OutFile "whisper-bin-win-opencl-adreno-arm64.zip"
$  Expand-Archive -Path ".\whisper-bin-win-opencl-adreno-arm64.zip" -DestinationPath "whisper-bin-win-opencl-adreno-arm64"
```
Run:
```console
$ .\whisper-bin-win-opencl-adreno-arm64\Release\whisper-cli.exe -m models\ggml-small.bin -f samples\jfk.wav
ggml_opencl: selected platform: 'NVIDIA CUDA'

ggml_opencl: device: 'NVIDIA RTX Spark (OpenCL 3.0 CUDA)'
ggml_opencl: unsupported GPU 'NVIDIA RTX Spark '.
ggml_opencl: drop unsupported device 'NVIDIA RTX Spark '.
load_backend: loaded OpenCL backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-opencl-adreno-arm64\Release\ggml-opencl.dll
load_backend: loaded CPU backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-opencl-adreno-arm64\Release\ggml-cpu.dll
whisper_init_from_file_with_params_no_state: loading model from 'models\ggml-small.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
whisper_init_with_params_no_state: devices    = 1
whisper_init_with_params_no_state: backends   = 2
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 768
whisper_model_load: n_audio_head  = 12
whisper_model_load: n_audio_layer = 12
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 768
whisper_model_load: n_text_head   = 12
whisper_model_load: n_text_layer  = 12
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 3 (small)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:          CPU total size =   487.01 MB
whisper_model_load: model size    =  487.01 MB
whisper_backend_init_gpu: device 0: CPU (type: 0)
whisper_backend_init_gpu: no GPU found
whisper_init_state: kv self size  =   18.87 MB
whisper_init_state: kv cross size =   56.62 MB
whisper_init_state: kv pad  size  =    4.72 MB
whisper_init_state: compute buffer (conv)   =   22.42 MB
whisper_init_state: compute buffer (encode) =   33.85 MB
whisper_init_state: compute buffer (cross)  =    6.20 MB
whisper_init_state: compute buffer (decode) =   97.28 MB
read_audio_data: reading audio data from 'samples\jfk.wav' ...
read_audio_data: trying to decode with miniaudio

system_info: n_threads = 4 / 18 | WHISPER : VITISAI = 0 | COREML = 0 | OPENVINO = 0 | CPU : NEON = 1 | ARM_FMA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | OPENMP = 1 | REPACK = 1 |

main: processing 'samples\jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = en, task = transcribe, timestamps = 1 ...


[00:00:00.000 --> 00:00:11.000]   And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =   357.59 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     6.85 ms
whisper_print_timings:   sample time =    94.17 ms /   147 runs (     0.64 ms per run)
whisper_print_timings:   encode time =  3556.36 ms /     1 runs (  3556.36 ms per run)
whisper_print_timings:   decode time =    10.94 ms /     1 runs (    10.94 ms per run)
whisper_print_timings:   batchd time =   768.50 ms /   144 runs (     5.34 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =  4813.57 ms
````

### CUDA 13.4
Download and unpack:
```console
$  Invoke-WebRequest -Uri "https://github.com/danbev/whisper.cpp/releases/download/b5130/whisper-bin-win-cuda-13.4.0-arm64.zip" -OutFile "whisper-bin-win-cuda-13.4.0-arm64.zip"
$  Expand-Archive -Path ".\whisper-bin-win-cuda-13.4.0-arm64.zip" -DestinationPath "whisper-bin-win-cuda-13.4.0-arm64"
```
Run:
```console
$ .\whisper-bin-win-cuda-13.4.0-arm64\Release\whisper-cli.exe -m .\models\ggml-small.bin -f .\samples\jfk.wav
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 46477 MiB):
  Device 0: NVIDIA RTX Spark (5120-core Blackwell RTX GPU), compute capability 12.1, VMM: yes, VRAM: 46477 MiB
load_backend: loaded CUDA backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-cuda-13.4.0-arm64\Release\ggml-cuda.dll
load_backend: loaded CPU backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-cuda-13.4.0-arm64\Release\ggml-cpu.dll
whisper_init_from_file_with_params_no_state: loading model from '.\models\ggml-small.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
whisper_init_with_params_no_state: devices    = 2
whisper_init_with_params_no_state: backends   = 2
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 768
whisper_model_load: n_audio_head  = 12
whisper_model_load: n_audio_layer = 12
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 768
whisper_model_load: n_text_head   = 12
whisper_model_load: n_text_layer  = 12
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 3 (small)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:        CUDA0 total size =   487.01 MB
whisper_model_load: model size    =  487.01 MB
whisper_backend_init_gpu: device 0: CUDA0 (type: 2)
whisper_backend_init_gpu: found GPU device 0: CUDA0 (type: 2, cnt: 0)
whisper_backend_init_gpu: using CUDA0 backend
whisper_init_state: kv self size  =   18.87 MB
whisper_init_state: kv cross size =   56.62 MB
whisper_init_state: kv pad  size  =    4.72 MB
whisper_init_state: compute buffer (conv)   =   23.38 MB
whisper_init_state: compute buffer (encode) =   33.85 MB
whisper_init_state: compute buffer (cross)  =    6.20 MB
whisper_init_state: compute buffer (decode) =   98.21 MB
read_audio_data: reading audio data from '.\samples\jfk.wav' ...
read_audio_data: trying to decode with miniaudio

system_info: n_threads = 4 / 18 | WHISPER : VITISAI = 0 | COREML = 0 | OPENVINO = 0 | CUDA : ARCHS = 750,800,860,890,900,1200,1210 | BLACKWELL_NATIVE_FP4 = 1 | CPU : NEON = 1 | ARM_FMA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | OPENMP = 1 | REPACK = 1 |

main: processing '.\samples\jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = en, task = transcribe, timestamps = 1 ...


[00:00:00.000 --> 00:00:11.000]   And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =   419.07 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     6.44 ms
whisper_print_timings:   sample time =    78.49 ms /   147 runs (     0.53 ms per run)
whisper_print_timings:   encode time =   131.90 ms /     1 runs (   131.90 ms per run)
whisper_print_timings:   decode time =    18.99 ms /     1 runs (    18.99 ms per run)
whisper_print_timings:   batchd time =   314.85 ms /   144 runs (     2.19 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =   990.31 ms
```

</details>