### PR TITLE
whisper : add language title API (#535)

### DIFF
--- a/include/whisper.h
+++ b/include/whisper.h
@@ -369,6 +369,9 @@ extern "C" {
     // Return the short string of the specified language name (e.g. 2 -> "german"), returns nullptr if not found
     WHISPER_API const char * whisper_lang_str_full(int id);
 
+    // Return the title of the specified language id (e.g. 2 -> "german"), returns nullptr if not found
+    WHISPER_API const char * whisper_lang_title(int id);
+
     // Use mel data at offset_ms to try and auto-detect the spoken language
     // Make sure to call whisper_pcm_to_mel() or whisper_set_mel() first
     // Returns the top language id or negative on failure

--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -4122,6 +4122,10 @@ const char * whisper_lang_str_full(int id) {
     return nullptr;
 }
 
+const char * whisper_lang_title(int id) {
+    return whisper_lang_str_full(id);
+}
+
 int whisper_lang_auto_detect_with_state(
         struct whisper_context * ctx,
           struct whisper_state * state,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -88,6 +88,14 @@ if (WHISPER_COMMON_FFMPEG)
     set_tests_properties(${TEST_TARGET} PROPERTIES LABELS "tiny;mp3")
 endif()
 
+# Language metadata API test
+set(LANG_TEST test-whisper-lang)
+add_executable(${LANG_TEST} ${LANG_TEST}.cpp)
+target_include_directories(${LANG_TEST} PRIVATE ../include)
+target_link_libraries(${LANG_TEST} PRIVATE whisper)
+add_test(NAME ${LANG_TEST} COMMAND ${LANG_TEST})
+set_tests_properties(${LANG_TEST} PROPERTIES LABELS "unit")
+
 # UTF-8 helper unit test
 set(UTF8_TEST test-common-utf8)
 add_executable(${UTF8_TEST} ${UTF8_TEST}.cpp)

--- a/tests/test-whisper-lang.cpp
+++ b/tests/test-whisper-lang.cpp
@@ -1,0 +1,14 @@
+#include "whisper.h"
+
+#include <cassert>
+#include <cstring>
+
+int main() {
+    assert(std::strcmp(whisper_lang_title(0), "english") == 0);
+    assert(std::strcmp(whisper_lang_title(2), "german") == 0);
+    assert(std::strcmp(whisper_lang_title(99), "cantonese") == 0);
+    assert(whisper_lang_title(-1) == nullptr);
+    assert(whisper_lang_title(whisper_lang_max_id() + 1) == nullptr);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `whisper_lang_title(int id)` to the public C API.
- Reuse the existing language title mapping and invalid-ID behavior.
- Add focused regression coverage for valid and invalid IDs.

## Validation
- Configured the repository test build with CMake.
- Built `test-whisper-lang`.
- Ran the focused CTest test successfully.

Validation observed for this change:
- `cmake -S . -B build-lang -DWHISPER_BUILD_TESTS=ON -DWHISPER_BUILD_SERVER=OFF`
- `cmake --build build-lang --target test-whisper-lang --parallel 2`
- `ctest --test-dir build-lang -R '^test-whisper-lang$' --output-on-failure`

Fixes #535

<!-- repo-agent-case:20e79b15-9e97-471f-a9bb-77773846a253 -->