### PR TITLE
ci : update WoA CUDA 13.4 to use 13.4.1 GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -691,7 +691,7 @@ jobs:
     strategy:
       matrix:
         build: [Release]
-        cuda-toolkit: [13.4.0]
+        cuda-toolkit: ['13.4']
 
     steps:
       - name: Clone repository
@@ -710,30 +710,37 @@ jobs:
       # nvcc cross-compiles for ARM64 from this x64 runner using the ARM64-targeting
       # host cl.exe; the CUDA runtime/cublas libs still need their own ARM64 archives
       # since the standard x64 CUDA packages don't ship ARM64 binaries.
-      - name: Install Cuda Toolkit 13.4.0 (ARM64 target)
+      - name: Install Cuda Toolkit 13.4 (ARM64 target)
         run: |
           $CUDA_TOOLKIT_DIR = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.4"
-          $PKG = "https://packages.nvidia.com/bin-archive/pool"
-          $PKG_ID = "5B515474-7E78-11F1-8656-C51E4F4B317F"
+          $CUDA_DOWNLOAD = "https://developer.download.nvidia.com/compute/cuda/redist"
+
+          # Components versions
+          $CCCL_VER   = "13.3.4.2.1"
+          $CRT_VER    = "13.4.59"
+          $NVCC_VER   = "13.4.59"
+          $NVVM_VER   = "13.4.59"
+          $CUDART_VER = "13.4.49"
+          $CUBLAS_VER = "13.7.0.27"
 
           mkdir -p $CUDA_TOOLKIT_DIR
           choco install unzip -y
 
-          curl -O "$PKG/windows-x86_64/$PKG_ID/cccl-windows-x86_64-13.3.4.1.2-archive.zip"
-          curl -O "$PKG/windows-x86_64/$PKG_ID/cuda_crt-windows-x86_64-13.4.46-archive.zip"
-          curl -O "$PKG/windows-x86_64/$PKG_ID/cuda_nvcc-windows-x86_64-13.4.46-archive.zip"
-          curl -O "$PKG/windows-x86_64/$PKG_ID/libnvvm-windows-x86_64-13.4.46-archive.zip"
-          curl -O "$PKG/windows-arm64/$PKG_ID/cuda_cudart-windows-arm64-13.4.46-archive.zip"
-          curl -O "$PKG/windows-arm64/$PKG_ID/libcublas-windows-arm64-13.7.0.10-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/cccl/windows-x86_64/cccl-windows-x86_64-${CCCL_VER}-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/cuda_crt/windows-x86_64/cuda_crt-windows-x86_64-${CRT_VER}-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/cuda_nvcc/windows-x86_64/cuda_nvcc-windows-x86_64-${NVCC_VER}-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/libnvvm/windows-x86_64/libnvvm-windows-x86_64-${NVVM_VER}-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/cuda_cudart/windows-arm64/cuda_cudart-windows-arm64-${CUDART_VER}-archive.zip"
+          curl -O "$CUDA_DOWNLOAD/libcublas/windows-arm64/libcublas-windows-arm64-${CUBLAS_VER}-archive.zip"
 
           unzip '*.zip' -d $CUDA_TOOLKIT_DIR
 
-          xcopy "$CUDA_TOOLKIT_DIR\cccl-windows-x86_64-13.3.4.1.2-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
-          xcopy "$CUDA_TOOLKIT_DIR\cuda_crt-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
-          xcopy "$CUDA_TOOLKIT_DIR\cuda_nvcc-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
-          xcopy "$CUDA_TOOLKIT_DIR\libnvvm-windows-x86_64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
-          xcopy "$CUDA_TOOLKIT_DIR\cuda_cudart-windows-arm64-13.4.46-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
-          xcopy "$CUDA_TOOLKIT_DIR\libcublas-windows-arm64-13.7.0.10-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cccl-windows-x86_64-${CCCL_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_crt-windows-x86_64-${CRT_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_nvcc-windows-x86_64-${NVCC_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\libnvvm-windows-x86_64-${NVVM_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\cuda_cudart-windows-arm64-${CUDART_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
+          xcopy "$CUDA_TOOLKIT_DIR\libcublas-windows-arm64-${CUBLAS_VER}-archive\*" "$CUDA_TOOLKIT_DIR" /E /I /H /Y
 
           echo "$CUDA_TOOLKIT_DIR\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
           echo "CUDA_PATH=$CUDA_TOOLKIT_DIR" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
@@ -910,8 +917,6 @@ jobs:
         with:
           tag_name: ${{ needs.determine-tag.outputs.tag_name }}
           prerelease: true
-          body: |
-            **Note:** the Windows arm64 (CUDA) build (`whisper-bin-win-cuda-*-arm64.zip`) uses a preview edition of the CUDA Toolkit for Windows on Arm and should be considered experimental.
 
       - name: Upload release
         id: upload_release


### PR DESCRIPTION

Refs: https://github.com/ggml-org/llama.cpp/pull/28687

----
<details><summary>Fork release</summary>

```console
$  Invoke-WebRequest -Uri "https://github.com/danbev/whisper.cpp/releases/download/b5129/whisper-bin-win-cuda-13.4.0-arm64.zip" -OutFile "whisper-bin-win-cuda-13.4.0-arm64.zip"

$  Expand-Archive -Path ".\whisper-bin-win-cuda-13.4.0-arm64.zip" -DestinationPath "whisper-bin-win-cuda-13.4.0-arm64"                              

$ .\whisper-bin-win-cuda-13.4.0-arm64\Release\whisper-cli.exe -m .\models\ggml-small.bin -f .\samples\jfk.wav
ggml_cuda_init: found 1 CUDA devices (Total VRAM: 46477 MiB):
  Device 0: NVIDIA RTX Spark N1X (5120-core Blackwell RTX GPU), compute capability 12.1, VMM: yes, VRAM: 46477 MiB
load_backend: loaded CUDA backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-cuda-13.4.0-arm64\Release\ggml-cuda.dll
load_backend: loaded CPU backend from C:\Users\P14\work\whisper.cpp\whisper-bin-win-cuda-13.4.0-arm64\Release\ggml-cpu.dll
whisper_init_from_file_with_params_no_state: loading model from '.\models\ggml-small.bin'
whisper_init_with_params_no_state: use gpu    = 1
whisper_init_with_params_no_state: flash attn = 1
whisper_init_with_params_no_state: gpu_device = 0
whisper_init_with_params_no_state: dtw        = 0
whisper_init_with_params_no_state: devices    = 2
whisper_init_with_params_no_state: backends   = 2
whisper_model_load: loading model
whisper_model_load: n_vocab       = 51865
whisper_model_load: n_audio_ctx   = 1500
whisper_model_load: n_audio_state = 768
whisper_model_load: n_audio_head  = 12
whisper_model_load: n_audio_layer = 12
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 768
whisper_model_load: n_text_head   = 12
whisper_model_load: n_text_layer  = 12
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 3 (small)
whisper_model_load: adding 1608 extra tokens
whisper_model_load: n_langs       = 99
whisper_model_load:        CUDA0 total size =   487.01 MB
whisper_model_load: model size    =  487.01 MB
whisper_backend_init_gpu: device 0: CUDA0 (type: 2)
whisper_backend_init_gpu: found GPU device 0: CUDA0 (type: 2, cnt: 0)
whisper_backend_init_gpu: using CUDA0 backend
whisper_init_state: kv self size  =   18.87 MB
whisper_init_state: kv cross size =   56.62 MB
whisper_init_state: kv pad  size  =    4.72 MB
whisper_init_state: compute buffer (conv)   =   23.38 MB
whisper_init_state: compute buffer (encode) =   33.85 MB
whisper_init_state: compute buffer (cross)  =    6.20 MB
whisper_init_state: compute buffer (decode) =   98.21 MB
read_audio_data: reading audio data from '.\samples\jfk.wav' ...
read_audio_data: trying to decode with miniaudio

system_info: n_threads = 4 / 18 | WHISPER : VITISAI = 0 | COREML = 0 | OPENVINO = 0 | CUDA : ARCHS = 750,800,860,890,900,1200,1210 | BLACKWELL_NATIVE_FP4 = 1 | CPU : NEON = 1 | ARM_FMA = 1 | MATMUL_INT8 = 1 | DOTPROD = 1 | OPENMP = 1 | REPACK = 1 |

main: processing '.\samples\jfk.wav' (176000 samples, 11.0 sec), 4 threads, 1 processors, 5 beams + best of 5, lang = en, task = transcribe, timestamps = 1 ...


[00:00:00.000 --> 00:00:11.000]   And so my fellow Americans, ask not what your country can do for you, ask what you can do for your country.

whisper_print_timings:     load time =   406.92 ms
whisper_print_timings:     fallbacks =   0 p /   0 h
whisper_print_timings:      mel time =     7.02 ms
whisper_print_timings:   sample time =    77.73 ms /   147 runs (     0.53 ms per run)
whisper_print_timings:   encode time =    59.48 ms /     1 runs (    59.48 ms per run)
whisper_print_timings:   decode time =    15.98 ms /     1 runs (    15.98 ms per run)
whisper_print_timings:   batchd time =   293.46 ms /   144 runs (     2.04 ms per run)
whisper_print_timings:   prompt time =     0.00 ms /     1 runs (     0.00 ms per run)
whisper_print_timings:    total time =   879.97 ms
```

</details>