### PR TITLE
go : free CString allocations in lang_id and params setters

### DIFF
--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -14,11 +14,22 @@ import (
 */
 import "C"
 
-func setOwnedCString(dst **C.char, s string) {
+func freeOwnedCString(dst **C.char) {
 	if *dst != nil {
 		C.free(unsafe.Pointer(*dst))
+		*dst = nil
 	}
+}
+
+func setOwnedCString(dst **C.char, s string) {
+	freeOwnedCString(dst)
 	*dst = C.CString(s)
+}
+
+// Free releases C strings owned by SetInitialPrompt and SetVADModelPath.
+func (p *Params) Free() {
+	freeOwnedCString(&p.initial_prompt)
+	freeOwnedCString(&p.vad_model_path)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/bindings/go/params.go
+++ b/bindings/go/params.go
@@ -2,15 +2,24 @@ package whisper
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 ///////////////////////////////////////////////////////////////////////////////
 // CGO
 
 /*
+#include <stdlib.h>
 #include <whisper.h>
 */
 import "C"
+
+func setOwnedCString(dst **C.char, s string) {
+	if *dst != nil {
+		C.free(unsafe.Pointer(*dst))
+	}
+	*dst = C.CString(s)
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // PUBLIC METHODS
@@ -53,7 +62,7 @@ func (p *Params) SetVAD(v bool) {
 }
 
 func (p *Params) SetVADModelPath(path string) {
-	p.vad_model_path = C.CString(path)
+	setOwnedCString(&p.vad_model_path, path)
 }
 
 func (p *Params) SetVADThreshold(t float32) {
@@ -176,7 +185,7 @@ func (p *Params) SetTemperatureFallback(t float32) {
 
 // Set initial prompt
 func (p *Params) SetInitialPrompt(prompt string) {
-	p.initial_prompt = C.CString(prompt)
+	setOwnedCString(&p.initial_prompt, prompt)
 }
 
 func (p *Params) SetCarryInitialPrompt(v bool) {

--- a/bindings/go/pkg/whisper/context.go
+++ b/bindings/go/pkg/whisper/context.go
@@ -30,6 +30,9 @@ func newContext(model *model, params whisper.Params) (Context, error) {
 	context := new(context)
 	context.model = model
 	context.params = params
+	runtime.SetFinalizer(context, func(c *context) {
+		c.params.Free()
+	})
 
 	// Return success
 	return context, nil

--- a/bindings/go/whisper.go
+++ b/bindings/go/whisper.go
@@ -178,7 +178,9 @@ func (ctx *Context) Whisper_tokenize(text string, tokens []Token) (int, error) {
 //	"de" -> 2
 //	"german" -> 2
 func (ctx *Context) Whisper_lang_id(lang string) int {
-	return int(C.whisper_lang_id(C.CString(lang)))
+	cLang := C.CString(lang)
+	defer C.free(unsafe.Pointer(cLang))
+	return int(C.whisper_lang_id(cLang))
 }
 
 // Largest language id (i.e. number of available languages - 1)


### PR DESCRIPTION
## Overview

`Whisper_lang_id` leaked the temporary C string. `SetInitialPrompt` and `SetVADModelPath` overwrote previous pointers without freeing them.

`Whisper_tokenize` already uses `C.CString` + `defer C.free`. `lang_id` now matches that. The params setters free the previous owned pointer before replacing it. Default params use NULL, so the first set is safe.

## Additional information

Fixes #4041
Fixes #4042
Fixes #4043

## Requirements

- I have read and agree with the contributing guidelines
- AI usage disclosure: NO