### PR TITLE
whisper : fail gracefully when model weight buffer allocation fails (#3386)

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -1858,12 +1858,17 @@ static bool whisper_model_load(struct whisper_model_loader * loader, whisper_con
         ggml_backend_buffer_type_t buft = p.first;
         ggml_context * ctx = p.second;
         ggml_backend_buffer_t buf = ggml_backend_alloc_ctx_tensors_from_buft(ctx, buft);
-        if (buf) {
-            model.buffers.emplace_back(buf);
-
-            size_t size_main = ggml_backend_buffer_get_size(buf);
-            WHISPER_LOG_INFO("%s: %12s total size = %8.2f MB\n", __func__, ggml_backend_buffer_name(buf), size_main / 1e6);
+        if (!buf) {
+            // out of memory: fail gracefully instead of leaving weight tensors with a
+            // null buffer, which crashes later when loading weights or freeing the model
+            WHISPER_LOG_ERROR("%s: failed to allocate memory for the model weights\n", __func__);
+            return false;
         }
+
+        model.buffers.emplace_back(buf);
+
+        size_t size_main = ggml_backend_buffer_get_size(buf);
+        WHISPER_LOG_INFO("%s: %12s total size = %8.2f MB\n", __func__, ggml_backend_buffer_name(buf), size_main / 1e6);
     }
 
     // load weights

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,14 @@ target_compile_definitions(${ZERO_SAMPLES_TEST} PRIVATE
 add_test(NAME ${ZERO_SAMPLES_TEST} COMMAND ${ZERO_SAMPLES_TEST})
 set_tests_properties(${ZERO_SAMPLES_TEST} PROPERTIES LABELS "tiny;gh")
 
+# out-of-memory during model load must fail gracefully, not crash (#3386)
+set(OOM_GRACEFUL_TEST test-whisper-oom-graceful)
+add_executable(${OOM_GRACEFUL_TEST} ${OOM_GRACEFUL_TEST}.cpp)
+target_include_directories(${OOM_GRACEFUL_TEST} PRIVATE ../include ../ggml/include ../examples)
+target_link_libraries(${OOM_GRACEFUL_TEST} PRIVATE common)
+add_test(NAME ${OOM_GRACEFUL_TEST} COMMAND ${OOM_GRACEFUL_TEST})
+set_tests_properties(${OOM_GRACEFUL_TEST} PROPERTIES LABELS "unit;gh")
+
 # VAD test tests VAD in isolation
 set(VAD_TEST test-vad)
 add_executable(${VAD_TEST} ${VAD_TEST}.cpp)

--- a/tests/test-whisper-oom-graceful.cpp
+++ b/tests/test-whisper-oom-graceful.cpp
@@ -1,0 +1,178 @@
+// Regression test for https://github.com/ggml-org/whisper.cpp/issues/3386
+//
+// When there is not enough free memory to allocate the model weight buffer,
+// whisper_model_load() used to silently skip the failed backend buffer and
+// continue loading weights into tensors whose ->buffer was still NULL. That
+// dereferenced a null buffer while loading weights (and again while freeing the
+// model, e.g. ggml_backend_metal_buffer_rset_free), crashing instead of failing
+// gracefully.
+//
+// This test builds a valid-enough in-memory model whose weight buffer is far too
+// large to allocate, caps the process address space so the allocation is
+// guaranteed to fail, and checks that whisper_init returns NULL instead of
+// crashing.
+
+#include "whisper.h"
+#include "ggml.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#if defined(__linux__) && !defined(__SANITIZE_ADDRESS__)
+
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// hugely oversized model dimensions so the weight buffer cannot be allocated
+static const int32_t HUGE_STATE   = 8192; // n_audio_state == n_text_state
+static const int32_t N_VOCAB      = 512;
+static const int32_t N_AUDIO_CTX  = 1500;
+static const int32_t N_TEXT_CTX   = 448;
+static const int32_t N_HEAD       = 8;
+static const int32_t N_LAYER      = 4;   // MODEL_TINY
+static const int32_t N_MELS       = 80;
+static const int32_t FTYPE_F16    = 1;   // GGML_FTYPE_MOSTLY_F16
+static const int32_t GGML_TYPE_F32_ID = 0;
+
+// address space headroom left for backend init / metadata after capping (bytes);
+// far smaller than the multi-GB weight buffer, so only the buffer alloc fails
+static const size_t  AS_HEADROOM  = (size_t) 256 * 1024 * 1024;
+
+static void put_i32(std::vector<uint8_t> & b, int32_t v) {
+    b.insert(b.end(), (uint8_t *) &v, (uint8_t *) &v + sizeof(v));
+}
+static void put_u32(std::vector<uint8_t> & b, uint32_t v) {
+    b.insert(b.end(), (uint8_t *) &v, (uint8_t *) &v + sizeof(v));
+}
+
+// build a whisper model buffer that parses far enough to attempt (and fail) the
+// weight buffer allocation, then feeds one real tensor header to reach the code
+// path that dereferences the (missing) buffer.
+static std::vector<uint8_t> build_oversized_model() {
+    std::vector<uint8_t> b;
+
+    put_u32(b, GGML_FILE_MAGIC);
+
+    // hparams
+    put_i32(b, N_VOCAB);
+    put_i32(b, N_AUDIO_CTX);
+    put_i32(b, HUGE_STATE);   // n_audio_state
+    put_i32(b, N_HEAD);
+    put_i32(b, N_LAYER);      // n_audio_layer
+    put_i32(b, N_TEXT_CTX);
+    put_i32(b, HUGE_STATE);   // n_text_state (must equal n_audio_state)
+    put_i32(b, N_HEAD);
+    put_i32(b, N_LAYER);      // n_text_layer
+    put_i32(b, N_MELS);
+    put_i32(b, FTYPE_F16);
+
+    // mel filters: n_mel, n_fft, then n_mel*n_fft floats
+    const int32_t f_n_mel = 80;
+    const int32_t f_n_fft = 1;
+    put_i32(b, f_n_mel);
+    put_i32(b, f_n_fft);
+    for (int i = 0; i < f_n_mel * f_n_fft; ++i) {
+        put_u32(b, 0); // one float each
+    }
+
+    // vocab: count, then [len, bytes] per token
+    put_i32(b, N_VOCAB);
+    for (int32_t i = 0; i < N_VOCAB; ++i) {
+        put_u32(b, 1);                       // token length
+        b.push_back((uint8_t) (i & 0xFF));   // token byte
+    }
+
+    // one real tensor header: encoder.positional_embedding, F32, [n_audio_state, n_audio_ctx]
+    const std::string name = "encoder.positional_embedding";
+    put_i32(b, 2);                       // n_dims
+    put_i32(b, (int32_t) name.size());   // name length
+    put_i32(b, GGML_TYPE_F32_ID);        // ttype
+    put_i32(b, HUGE_STATE);              // ne[0]
+    put_i32(b, N_AUDIO_CTX);             // ne[1]
+    b.insert(b.end(), name.begin(), name.end());
+    // no tensor data: load crashes (unfixed) / returns false (fixed) before it is read
+
+    return b;
+}
+
+static size_t current_address_space_bytes() {
+    // /proc/self/statm field 1 = total program size, in pages
+    FILE * f = fopen("/proc/self/statm", "r");
+    if (!f) {
+        return 0;
+    }
+    unsigned long pages = 0;
+    if (fscanf(f, "%lu", &pages) != 1) {
+        pages = 0;
+    }
+    fclose(f);
+    return (size_t) pages * (size_t) sysconf(_SC_PAGESIZE);
+}
+
+int main() {
+    std::vector<uint8_t> model = build_oversized_model();
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        perror("fork");
+        return 1;
+    }
+
+    if (pid == 0) {
+        // child: cap the address space so the weight buffer allocation must fail,
+        // then attempt to load the model. Never crash if the fix is present.
+        size_t cap = current_address_space_bytes() + AS_HEADROOM;
+        struct rlimit rl;
+        rl.rlim_cur = cap;
+        rl.rlim_max = cap;
+        if (setrlimit(RLIMIT_AS, &rl) != 0) {
+            perror("setrlimit");
+            _exit(3);
+        }
+
+        struct whisper_context_params cparams = whisper_context_default_params();
+        cparams.use_gpu = false;
+
+        struct whisper_context * ctx =
+            whisper_init_from_buffer_with_params(model.data(), model.size(), cparams);
+
+        if (ctx == nullptr) {
+            _exit(0); // graceful failure — expected with the fix
+        }
+        whisper_free(ctx);
+        _exit(2); // unexpectedly succeeded (buffer somehow allocated)
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) < 0) {
+        perror("waitpid");
+        return 1;
+    }
+
+    if (WIFSIGNALED(status)) {
+        printf("test-whisper-oom-graceful: RED — model load crashed with signal %d on allocation failure\n",
+               WTERMSIG(status));
+        return 1;
+    }
+    if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+        printf("test-whisper-oom-graceful: GREEN — whisper_init returned NULL gracefully on allocation failure\n");
+        return 0;
+    }
+
+    printf("test-whisper-oom-graceful: FAIL — unexpected child status (exit code %d)\n",
+           WIFEXITED(status) ? WEXITSTATUS(status) : -1);
+    return 1;
+}
+
+#else // not Linux, or built with AddressSanitizer (incompatible with RLIMIT_AS)
+
+int main() {
+    printf("test-whisper-oom-graceful: SKIP — requires Linux without AddressSanitizer\n");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
whisper_model_load silently skipped a failed backend weight-buffer allocation and kept loading weights into tensors with a null buffer, crashing on OOM (e.g. ggml_backend_metal_buffer_rset_free). Return an error instead, so whisper_init returns NULL gracefully. Adds a regression test that caps the address space to force the allocation failure.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
whisper_model_load: n_text_ctx    = 448
whisper_model_load: n_text_state  = 8192
whisper_model_load: n_text_head   = 8
whisper_model_load: n_text_layer  = 4
whisper_model_load: n_mels        = 80
whisper_model_load: ftype         = 1
whisper_model_load: qntvr         = 0
whisper_model_load: type          = 1 (tiny)
whisper_model_load: n_langs       = -51253
ggml_aligned_malloc: insufficient memory (attempted to allocate 14796.44 MB)
ggml_backend_cpu_buffer_type_alloc_buffer: failed to allocate buffer of size 15515189248
alloc_tensor_range: failed to allocate CPU buffer of size 15515189248
/home/ousama/contribute-work/ggml-org__whisper.cpp/ggml/src/ggml-backend.cpp:205: GGML_ASSERT(buffer) failed
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libggml-base.so.0(+0x1b236) [0x742129742236]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libggml-base.so.0(ggml_print_backtrace+0x20d) [0x7421297426bd]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libggml-base.so.0(ggml_abort+0x166) [0x7421297428a6]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libggml-base.so.0(ggml_backend_buffer_name+0x0) [0x74212975b030]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libggml-base.so.0(ggml_backend_buffer_is_host+0xd) [0x74212975b09d]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libwhisper.so.1(+0x3c2b6) [0x742129ba22b6]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libwhisper.so.1(whisper_init_with_params_no_state+0x292) [0x742129ba39a2]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libwhisper.so.1(whisper_init_from_buffer_with_params_no_state+0xa7) [0x742129ba3bb7]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/libwhisper.so.1(whisper_init_from_buffer_with_params+0x2e) [0x742129baa5ee]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/test-whisper-oom-graceful(+0x1fac) [0x5d91fb8acfac]
/usr/lib/x86_64-linux-gnu/libc.so.6(+0x2a601) [0x74212942a601]
/usr/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x88) [0x74212942a718]
/home/ousama/contribute-work/ggml-org__whisper.cpp/build/bin/test-whisper-oom-graceful(+0x23f5) [0x5d91fb8ad3f5]
test-whisper-oom-graceful: RED — model load crashed with signal 6 on allocation failure


0% tests passed, 1 tests failed out of 1

Label Time Summary:
gh      =   0.01 sec*proc (1 test)
unit    =   0.01 sec*proc (1 test)

Total Test time (real) =   0.01 sec

The following tests FAILED:
	 13 - test-whisper-oom-graceful (Failed)                gh unit
Errors while running CTest
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
[ 26%] Built target ggml-base
[ 68%] Built target ggml-cpu
[ 76%] Built target ggml
[ 81%] Built target whisper
[ 94%] Built target common
[100%] Built target test-whisper-oom-graceful
Test project /home/ousama/contribute-work/ggml-org__whisper.cpp/build
    Start 13: test-whisper-oom-graceful
1/1 Test #13: test-whisper-oom-graceful ........   Passed    0.01 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
gh      =   0.01 sec*proc (1 test)
unit    =   0.01 sec*proc (1 test)

Total Test time (real) =   0.01 sec
```

## Full local suite

Command: `cmake -B build -DGGML_NATIVE=OFF -DWHISPER_BUILD_EXAMPLES=ON -DWHISPER_BUILD_TESTS=ON && cmake --build build -j4 && ctest --test-dir build -L unit --output-on-failure`

```
[ 71%] Linking CXX executable ../bin/test-parakeet
[ 72%] Built target test-whisper-oom-graceful
[ 73%] Linking CXX executable ../bin/test-parakeet-full-jfk
[ 75%] Built target test-vad
[ 76%] Built target test-parakeet
[ 77%] Linking CXX executable ../bin/test-parakeet-full-gb1
[ 78%] Built target test-vad-full
[ 80%] Linking CXX executable ../bin/test-parakeet-full-diffusion
[ 81%] Linking CXX executable ../../bin/whisper-cli
[ 82%] Built target test-parakeet-full-jfk
[ 84%] Linking CXX executable ../../bin/whisper-server
[ 85%] Built target test-parakeet-full-gb1
[ 86%] Built target test-parakeet-full-diffusion
[ 88%] Linking CXX executable ../../bin/whisper-quantize
[ 89%] Linking CXX executable ../../bin/whisper-vad-speech-segments
[ 90%] Built target whisper-cli
[ 92%] Linking CXX executable ../../bin/parakeet-cli
[ 93%] Built target whisper-server
[ 94%] Built target whisper-quantize
[ 96%] Linking CXX executable ../../bin/parakeet-quantize
[ 97%] Built target whisper-vad-speech-segments
[ 98%] Built target parakeet-cli
[100%] Built target parakeet-quantize
Test project /home/ousama/contribute-work/ggml-org__whisper.cpp/build
    Start 10: test-common-utf8
1/4 Test #10: test-common-utf8 .................   Passed    0.00 sec
    Start 11: test-whisper-buffer-loader
2/4 Test #11: test-whisper-buffer-loader .......   Passed    0.00 sec
    Start 13: test-whisper-oom-graceful
3/4 Test #13: test-whisper-oom-graceful ........   Passed    0.01 sec
    Start 14: test-vad
4/4 Test #14: test-vad .........................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 4

Label Time Summary:
gh      =   0.01 sec*proc (2 tests)
unit    =   0.05 sec*proc (4 tests)

Total Test time (real) =   0.05 sec
```

Fix #3386
