### PR TITLE
whisper_full_parallel: fix signed 32-bit overflow in chunk timestamp …

### DIFF
--- a/src/whisper.cpp
+++ b/src/whisper.cpp
@@ -7911,6 +7911,13 @@ int whisper_full(
     return whisper_full_with_state(ctx, ctx->state, params, samples, n_samples);
 }
 
+// Chunk boundary offset (in centiseconds) for the `i_plus_1`-th `whisper_full_parallel` split.
+// Promotes to int64_t before multiplying: `100 * chunk_start_samples` alone can exceed INT_MAX
+// for audio longer than ~22 minutes at 16 kHz, overflowing a 32-bit int (issue #4039).
+static int64_t whisper_full_parallel_chunk_offset(int i_plus_1, int n_samples_per_processor, int64_t offset_t) {
+    return 100LL * i_plus_1 * n_samples_per_processor / WHISPER_SAMPLE_RATE + offset_t;
+}
+
 int whisper_full_parallel(
         struct whisper_context * ctx,
         struct whisper_full_params params,
@@ -7989,10 +7996,12 @@ int whisper_full_parallel(
     for (int i = 0; i < n_processors - 1; ++i) {
         auto& results_i = states[i]->result_all;
 
+        const int64_t chunk_offset_t = whisper_full_parallel_chunk_offset(i + 1, n_samples_per_processor, offset_t);
+
         for (auto& result : results_i) {
             // correct the segment timestamp taking into account the offset
-            result.t0 += 100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
-            result.t1 += 100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;
+            result.t0 += chunk_offset_t;
+            result.t1 += chunk_offset_t;
 
             // make sure that segments are not overlapping
             if (!ctx->state->result_all.empty()) {
@@ -8034,7 +8043,8 @@ int whisper_full_parallel(
     WHISPER_LOG_WARN("\n");
     WHISPER_LOG_WARN("%s: the audio has been split into %d chunks at the following times:\n", __func__, n_processors);
     for (int i = 0; i < n_processors - 1; ++i) {
-        WHISPER_LOG_WARN("%s: split %d - %s\n", __func__, (i + 1), to_timestamp(100*((i + 1)*n_samples_per_processor)/WHISPER_SAMPLE_RATE + offset_t).c_str());
+        const int64_t split_t = whisper_full_parallel_chunk_offset(i + 1, n_samples_per_processor, offset_t);
+        WHISPER_LOG_WARN("%s: split %d - %s\n", __func__, (i + 1), to_timestamp(split_t).c_str());
     }
     WHISPER_LOG_WARN("%s: the transcription quality may be degraded near these boundaries\n", __func__);
 


### PR DESCRIPTION
…offset

`n_samples_per_processor` and `i` are plain `int`. Both call sites computed `100 * ((i + 1) * n_samples_per_processor)` entirely in 32-bit `int` before dividing by `WHISPER_SAMPLE_RATE` and only then adding the `int64_t` offset:

    result.t0 += 100 * ((i + 1) * n_samples_per_processor) / WHISPER_SAMPLE_RATE + offset_t;

At 16 kHz, `100 * chunk_start_samples` exceeds INT_MAX once a chunk boundary is later than ~22 minutes 22 seconds, corrupting both the merged segment t0/t1 timestamps and the printed split positions for long audio processed with more than one processor.

Extracted the shared arithmetic into `whisper_full_parallel_chunk_offset`, promoting to `int64_t` before multiplying (`100LL * i_plus_1 * ...`), and used it at both the segment-merge site and the split-reporting site, removing the duplication as well as the overflow.

Verified with a standalone reproduction of the issue's exact scenario (3630.8s @ 16kHz, 4 processors): the old formula (built with -fwrapv to show the defined-wraparound case rather than relying on UB) produces -868.95s for split 2 and 38.74s for split 3, matching the issue's reported "00:-14:-28.-960" and "wrapped timeline crossed zero" symptoms exactly. The fixed formula produces 1815.40s and 2723.10s (~30 and ~45 minutes), matching the issue's stated expected result.

A full end-to-end regression test would need either exposing this internal helper through the public API or running whisper_full_parallel over >22 minutes of synthetic audio through actual inference, which seemed disproportionate for a pure-arithmetic fix; happy to add either if maintainers would prefer it.

Closes #4039